### PR TITLE
refactor: simplifying binary fieldtype props and logic

### DIFF
--- a/app/guides/BinaryFieldTypeGuide.js
+++ b/app/guides/BinaryFieldTypeGuide.js
@@ -8,109 +8,100 @@ export class BinaryFieldTypeGuide extends Component {
   render() {
     return (
       <React.Fragment>
-        <p>Binary Field Type for manager app</p>
-        <p>Props: label, trueValue, falseValue, defaultChecked, disabled</p>
+        <h1>Binary Field Type</h1>
+        <h2>Props: label, on, off, checked, disabled, callback</h2>
         <br />
-        <BinaryFieldType label="Default Values" options={'1:Yes;0:No'} />
-        <br />
-        <BinaryFieldType
-          label="Custom Values"
-          callback={value => console.log(value)}
-          options={'1:Yes;0:No'}
-        />
-        <br />
-        <BinaryFieldType
-          label="1:No;0:Yes"
-          callback={value => console.log(value)}
-          default={1}
-          options={'1:No;0:Yes'}
-        />
-        <br />
-        <BinaryFieldType
-          label="something and something else"
-          callback={value => console.log(value)}
-          default={0}
-          options={'1:Something; 0:Something Else'}
-        />
-        <CodeCard header="Usage" height="440" open>
-          {`
-<BinaryFieldType label="Default Values" options={'1:Yes;0:No'} />
-<br />
-<BinaryFieldType
-  label="Custom Values"
-  callback={value => console.log(value)}
-  options={'1:Yes;0:No'}
-/>
-<br />
-<BinaryFieldType
-  label="1:No;0:Yes"
-  callback={value => console.log(value)}
-  default={1}
-  options={'1:No;0:Yes'}
-/>
-<br />
-<BinaryFieldType
-  label="something and something else"
-  callback={value => console.log(value)}
-  default={0}
-  options={'1:Something; 0:Something Else'}
-/>`}
-        </CodeCard>
 
-        <CodeCard header="Code" height="440">
-          {`export class BinaryFieldType extends Component {
-  state = {
-    checked: this.props.default === 1,
-    trueLabel: 'Yes',
-    falseLabel: 'No'
-  }
-  componentDidMount() {
-    console.log(this.props.options)
-    // determine labels
-    // label 1 and 0 properly
-    const binaryOptions = {
-      0: this.props.options.split(';').find(el => el.includes('0')),
-      1: this.props.options.split(';').find(el => el.includes('1'))
-    }
-    this.setState({
-      trueLabel: binaryOptions[1].split(':')[0],
-      falseLabel: binaryOptions[0].split(':')[0]
-    })
-  }
-  onChange(evt) {
-    // currently need to return a 1 or 0
-    if (this.props.callback) {
-      this.props.callback(evt.target.checked ? 1 : 0)
-    }
-    this.setState({
-      checked: evt.target.checked
-    })
-  }
-  render() {
-    const { falseLabel, trueLabel, checked } = this.state
-    const { label, disabled } = this.props
-    return (
-      <article className={styles.BinaryFieldType}>
-        <div className={styles.BinaryFieldTypeLabel}>
-          <label>{label}</label>
-        </div>
-        <label className={styles.switch}>
-          <input
-            checked={checked}
-            disabled={disabled}
-            onChange={evt => this.onChange(evt)}
-            type="checkbox"
-            data-text-on={trueLabel}
-            data-text-off={falseLabel}
-          />
-          <span className={styles.slider} />
-        </label>
-      </article>
-    )
-  }
-}`}
+        <h3>Default Usage</h3>
+        <BinaryFieldType />
+        <br />
+
+        <h3>Custom Label, On and Off Values</h3>
+        <BinaryFieldType label="Custom Label" on="On Value" off="Off Value" />
+        <br />
+
+        <h3>Pre-Checked</h3>
+        <BinaryFieldType checked />
+        <br />
+
+        <h3>Disabled</h3>
+        <BinaryFieldType disabled />
+        <br />
+
+        <h3>Callback</h3>
+        <BinaryFieldType
+          callback={val => {
+            alert(`Changed value: ${val}`)
+          }}
+        />
+        <br />
+
+        <CodeCard header="Usage" height="125" open>
+          {`<BinaryFieldType
+  label="Custom Label"
+  on="On Value"
+  off="Off Value"
+  callback={(val) => {
+    alert('Changed value')
+  }}
+/>`}
         </CodeCard>
       </React.Fragment>
     )
   }
 }
+
+//
+//         <CodeCard header="Code" height="440">
+//           {`export class BinaryFieldType extends Component {
+//   state = {
+//     checked: this.props.default === 1,
+//     trueLabel: 'Yes',
+//     falseLabel: 'No'
+//   }
+//   componentDidMount() {
+//     console.log(this.props.options)
+//     // determine labels
+//     // label 1 and 0 properly
+//     const binaryOptions = {
+//       0: this.props.options.split(';').find(el => el.includes('0')),
+//       1: this.props.options.split(';').find(el => el.includes('1'))
+//     }
+//     this.setState({
+//       trueLabel: binaryOptions[1].split(':')[0],
+//       falseLabel: binaryOptions[0].split(':')[0]
+//     })
+//   }
+//   onChange(evt) {
+//     // currently need to return a 1 or 0
+//     if (this.props.callback) {
+//       this.props.callback(evt.target.checked ? 1 : 0)
+//     }
+//     this.setState({
+//       checked: evt.target.checked
+//     })
+//   }
+//   render() {
+//     const { falseLabel, trueLabel, checked } = this.state
+//     const { label, disabled } = this.props
+//     return (
+//       <article className={styles.BinaryFieldType}>
+//         <div className={styles.BinaryFieldTypeLabel}>
+//           <label>{label}</label>
+//         </div>
+//         <label className={styles.switch}>
+//           <input
+//             checked={checked}
+//             disabled={disabled}
+//             onChange={evt => this.onChange(evt)}
+//             type="checkbox"
+//             data-text-on={trueLabel}
+//             data-text-off={falseLabel}
+//           />
+//           <span className={styles.slider} />
+//         </label>
+//       </article>
+//     )
+//   }
+// }`}
+//         </CodeCard>

--- a/core/src/BinaryFieldType/BinaryFieldType.js
+++ b/core/src/BinaryFieldType/BinaryFieldType.js
@@ -1,24 +1,12 @@
 import React, { Component } from "react";
-
 import styles from "./BinaryFieldType.less";
+
 export class BinaryFieldType extends Component {
-  state = {
-    checked: this.props.default === 1,
-    trueLabel: "Yes",
-    falseLabel: "No"
-  };
-  componentDidMount() {
-    // determine labels
-    // label 1 and 0 properly
-    const binaryOptions = {
-      0: this.props.options.split(";").find(el => el.includes("0")),
-      1: this.props.options.split(";").find(el => el.includes("1"))
+  constructor(props) {
+    super();
+    this.state = {
+      checked: Boolean(props.checked)
     };
-    this.setState({
-      trueLabel: binaryOptions[1].split(":")[1],
-      falseLabel: binaryOptions[0].split(":")[1],
-      checked: this.props.default === 1
-    });
   }
   onChange(evt) {
     // currently need to return a 1 or 0
@@ -34,21 +22,19 @@ export class BinaryFieldType extends Component {
     );
   }
   render() {
-    const { falseLabel, trueLabel, checked } = this.state;
-    const { label, disabled } = this.props;
     return (
       <article className={styles.BinaryFieldType}>
         <div className={styles.BinaryFieldTypeLabel}>
-          <label>{label}</label>
+          <label>{this.props.label}</label>
         </div>
         <label className={styles.switch}>
           <input
-            checked={checked}
-            disabled={disabled}
-            onChange={evt => this.onChange(evt)}
             type="checkbox"
-            data-text-on={trueLabel}
-            data-text-off={falseLabel}
+            checked={this.state.checked}
+            disabled={this.props.disabled}
+            onChange={evt => this.onChange(evt)}
+            data-text-on={this.props.on || "Yes"}
+            data-text-off={this.props.off || "No"}
           />
           <span className={styles.slider} />
         </label>


### PR DESCRIPTION
Changing the `BinaryFieldType` to have the consumer be in charge of formatting data to the structure the component needs.

## Props
- label
- ~trueValue~  
- ~falseValue~
- ~defaultChecked~ 
- disabled
- callback
- on *user provided custom on value*
- off *user provided custom off value*
- checked
