### PR TITLE
Abstracts field labels, descriptions. Adds tags and tooltips 

### DIFF
--- a/app/guides/BinaryFieldTypeGuide.js
+++ b/app/guides/BinaryFieldTypeGuide.js
@@ -12,20 +12,16 @@ export class BinaryFieldTypeGuide extends Component {
         <h2>Props: label, on, off, checked, disabled, callback</h2>
         <br />
 
-        <h3>Default Usage</h3>
-        <BinaryFieldType />
-        <br />
-
-        <h3>Custom Label, On and Off Values</h3>
         <BinaryFieldType
           label="Custom Label"
+          tooltip="Don't be a tooltip?"
+          description="Description text down here..."
           onValue="On Value"
           offValue="Off Value"
         />
         <br />
 
-        <h3>Pre-Checked</h3>
-        <BinaryFieldType default />
+        <BinaryFieldType label="Pre-Checked" default />
         <br />
 
         <h3>Disabled</h3>

--- a/app/guides/ColorFieldTypeGuide.js
+++ b/app/guides/ColorFieldTypeGuide.js
@@ -13,11 +13,16 @@ export class ColorFieldTypeGuide extends Component {
         <br />
         <ColorFieldType
           required
+          tooltip="Dont be a tooltip!"
           label="Title Field"
           callback={value => console.log(value)}
         />
         <br />
-        <ColorFieldType label="Default to Orange Field" value="#ff9920" />
+        <ColorFieldType
+          label="Default to Orange Field"
+          value="#ff9920"
+          description="Pick a pretty color... test description"
+        />
         <br />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/DateFieldTypeGuide.js
+++ b/app/guides/DateFieldTypeGuide.js
@@ -22,7 +22,10 @@ export class DateFieldTypeGuide extends Component {
           required
           onChange={console.log}
           datatype={'datetime'}
+          description="this one has a description!"
         />
+        <br />
+        <br />
         <DateFieldType
           label="Format Date"
           name="datepicker"

--- a/app/guides/DateTimeFieldTypeGuide.js
+++ b/app/guides/DateTimeFieldTypeGuide.js
@@ -16,7 +16,12 @@ export class DateTimeFieldTypeGuide extends Component {
         <br />
         <br />
         <DateTimeFieldType required label="Title Field" />
-        <DateTimeFieldType label="Title Field" timeFormat="HH:mm:ss" />
+        <br />
+        <DateTimeFieldType
+          label="Title Field"
+          timeFormat="HH:mm:ss"
+          description="This is my description"
+        />
         <br />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/DropDownFieldTypeGuide.js
+++ b/app/guides/DropDownFieldTypeGuide.js
@@ -16,6 +16,7 @@ export class DropDownFieldTypeGuide extends Component {
           tooltip="Hello World of Tooltips"
           callback={value => console.log(value)}
           description="Description Text down below"
+          tag="parsley_name"
           options={[
             { value: 'a value that can be used in some way', text: 'hi' },
             { value: 'a value that can be used in some way', text: 'hello' },
@@ -34,8 +35,9 @@ export class DropDownFieldTypeGuide extends Component {
             code={`
 <DropDownFieldType
   label="Label Field"
-  description="optional"
-  tooltip="text tooltip"
+  description="Description Text down below"
+  tag="parsley_name"
+  tooltip="Hello World of Tooltips"
   options={[
     { value: 'a value that can be used in some way', text: 'hi' },
     { value: 'a value that can be used in some way', text: 'hello' },

--- a/app/guides/DropDownFieldTypeGuide.js
+++ b/app/guides/DropDownFieldTypeGuide.js
@@ -14,6 +14,7 @@ export class DropDownFieldTypeGuide extends Component {
         <DropDownFieldType
           label="Label Field"
           callback={value => console.log(value)}
+          description="Description Text down below"
           options={[
             { value: 'a value that can be used in some way', text: 'hi' },
             { value: 'a value that can be used in some way', text: 'hello' },

--- a/app/guides/DropDownFieldTypeGuide.js
+++ b/app/guides/DropDownFieldTypeGuide.js
@@ -13,6 +13,7 @@ export class DropDownFieldTypeGuide extends Component {
         <br />
         <DropDownFieldType
           label="Label Field"
+          tooltip="Hello World of Tooltips"
           callback={value => console.log(value)}
           description="Description Text down below"
           options={[
@@ -33,6 +34,8 @@ export class DropDownFieldTypeGuide extends Component {
             code={`
 <DropDownFieldType
   label="Label Field"
+  description="optional"
+  tooltip="text tooltip"
   options={[
     { value: 'a value that can be used in some way', text: 'hi' },
     { value: 'a value that can be used in some way', text: 'hello' },

--- a/app/guides/EditorFieldTypeGuide.js
+++ b/app/guides/EditorFieldTypeGuide.js
@@ -13,6 +13,8 @@ export class EditorFieldTypeGuide extends Component {
           name="wysiwyg_basic"
           onChange={console.log}
           value=""
+          tooltip="Don't be a tooltip"
+          description="Write your description here..."
         />
       </React.Fragment>
     )

--- a/app/guides/ImageFieldTypeGuide.js
+++ b/app/guides/ImageFieldTypeGuide.js
@@ -27,6 +27,7 @@ export class ImageFieldTypeGuide extends Component {
           label="Title Field"
           limit="5"
           description="Images description to load here and test"
+          tooltip="Hello World"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/ImageFieldTypeGuide.js
+++ b/app/guides/ImageFieldTypeGuide.js
@@ -26,6 +26,7 @@ export class ImageFieldTypeGuide extends Component {
           callback={this.handleImages}
           label="Title Field"
           limit="5"
+          description="Images description to load here and test"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/NumberFieldTypeGuide.js
+++ b/app/guides/NumberFieldTypeGuide.js
@@ -23,11 +23,13 @@ export class NumberFieldTypeGuide extends Component {
           value="4"
           callback={value => console.log(value)}
         />
+        <br />
         <NumberFieldType
           label="No CharCount"
           required={true}
           value="4"
           callback={value => console.log(value)}
+          description="hello world im a description"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/OneToOneFieldTypeGuide.js
+++ b/app/guides/OneToOneFieldTypeGuide.js
@@ -14,6 +14,7 @@ export class OneToOneFieldTypeGuide extends Component {
         <OneToOneFieldType
           label="Label Field"
           callback={value => console.log(value)}
+          description="Test description"
           options={[
             { value: 'a value that can be used in some way', text: 'hi' },
             { value: 'a value that can be used in some way', text: 'hello' },

--- a/app/guides/SortFieldTypeGuide.js
+++ b/app/guides/SortFieldTypeGuide.js
@@ -18,6 +18,7 @@ export class SortFieldTypeGuide extends Component {
           label="Default to 10"
           default={10}
           callback={console.log}
+          description="This is the description text"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/TextFieldTypeGuide.js
+++ b/app/guides/TextFieldTypeGuide.js
@@ -39,27 +39,28 @@ export class TextFieldTypeGuide extends Component {
         <h3>charCount</h3>
         <p>Custom character count to display</p>
         <br />
-
         <h2>Examples</h2>
-        <TextFieldType
-          label="Title Field"
-          name="example1"
-          placeholder="placeholder text"
-          value={this.state.example1}
-          onChange={(name, value) => this.setState({ [name]: value })}
-        />
-
-        <TextFieldType
-          label="Custom Length"
-          name="example2"
-          maxLength="400"
-          required={true}
-          value={this.state.example2}
-          onChange={(name, value) => this.setState({ [name]: value })}
-          description="This is My Description"
-          placeholder="My Placeholder Text"
-        />
-
+        <div style={{ padding: '10px 0px' }}>
+          <TextFieldType
+            label="Title Field"
+            name="example1"
+            placeholder="placeholder text"
+            value={this.state.example1}
+            onChange={(name, value) => this.setState({ [name]: value })}
+          />
+        </div>
+        <div style={{ padding: '10px 0px' }}>
+          <TextFieldType
+            label="Custom Length"
+            name="example2"
+            maxLength="400"
+            required={true}
+            value={this.state.example2}
+            onChange={(name, value) => this.setState({ [name]: value })}
+            description="This is My Description"
+            placeholder="My Placeholder Text"
+          />
+        </div>
         <br />
         <CollapsibleCard header="Usage" open>
           <GithubEmbed

--- a/app/guides/TextFieldTypeGuide.js
+++ b/app/guides/TextFieldTypeGuide.js
@@ -56,13 +56,15 @@ export class TextFieldTypeGuide extends Component {
           required={true}
           value={this.state.example2}
           onChange={(name, value) => this.setState({ [name]: value })}
+          description="This is My Description"
+          placeholder="My Placeholder Text"
         />
 
         <br />
         <CollapsibleCard header="Usage" open>
           <GithubEmbed
             height="50px"
-            code="<TextFieldType label=&quot;Title Field&quot; maxLength=&quot;150&quot; />"
+            code='<TextFieldType label="Title Field" maxLength="150" />'
           />
         </CollapsibleCard>
         <CollapsibleCard header="Code" collapsed>

--- a/app/guides/TextareaFieldTypeGuide.js
+++ b/app/guides/TextareaFieldTypeGuide.js
@@ -32,6 +32,7 @@ export class TextareaFieldTypeGuide extends Component {
           onChange={(name, value) => this.setState({ [name]: value })}
           label="No CharCount prop"
           description="This is my description text"
+          tooltip="tooltip is rocking out"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/TextareaFieldTypeGuide.js
+++ b/app/guides/TextareaFieldTypeGuide.js
@@ -31,6 +31,7 @@ export class TextareaFieldTypeGuide extends Component {
           value={this.state.example2}
           onChange={(name, value) => this.setState({ [name]: value })}
           label="No CharCount prop"
+          description="This is my description text"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/guides/TextareaGuide.js
+++ b/app/guides/TextareaGuide.js
@@ -37,6 +37,7 @@ export class TextareaGuide extends Component {
               <Textarea
                 name="example2"
                 value="This textarea is required"
+                description="This is my description text"
                 required
               />
 

--- a/app/guides/UUIDFieldTypeGuide.js
+++ b/app/guides/UUIDFieldTypeGuide.js
@@ -24,6 +24,14 @@ export class UUIDFieldTypeGuide extends Component {
           onChange={this.onChange}
         />
         <br />
+        <UUIDFieldType
+          name="uuidField"
+          label="UUID field type"
+          value={this.state.value}
+          onChange={this.onChange}
+          description="This is a test description"
+        />
+        <br />
         <CollapsibleCard header="Usage" open>
           <GithubEmbed
             height="150px"

--- a/app/guides/UrlFieldTypeGuide.js
+++ b/app/guides/UrlFieldTypeGuide.js
@@ -22,6 +22,7 @@ export class UrlFieldTypeGuide extends Component {
           default="https://www.defaultURL.com"
           callback={console.log}
           label="No Charcount"
+          description="This is my description text"
         />
         <br />
         <CollapsibleCard header="Usage" open>

--- a/app/views/app/app.less
+++ b/app/views/app/app.less
@@ -91,6 +91,10 @@
         grid-gap: 1rem;
         min-width: 10rem;
       }
+
+      .field {
+        padding: 20px 0px;
+      }
     }
   }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zesty-io/core",
-  "version": "0.4.6",
+  "version": "0.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zesty-io/core",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2240,7 +2240,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -2408,7 +2408,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2550,7 +2550,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2579,7 +2579,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -2884,7 +2884,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2921,7 +2921,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2975,7 +2975,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3116,7 +3116,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -3605,7 +3605,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3618,7 +3618,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3694,7 +3694,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -4001,7 +4001,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -4189,7 +4189,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -4250,7 +4250,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -5651,7 +5651,7 @@
     },
     "globby": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
       "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
       "dev": true,
       "requires": {
@@ -5761,7 +5761,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -5779,7 +5779,7 @@
         },
         "through2": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
@@ -8115,7 +8115,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
@@ -8171,7 +8171,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8280,7 +8280,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -8625,12 +8625,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -8639,7 +8639,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -8830,7 +8830,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -8982,7 +8982,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         }
@@ -9559,7 +9559,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -9614,7 +9614,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -9918,7 +9918,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -10037,7 +10037,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -10256,7 +10256,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -10657,7 +10657,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -10689,7 +10689,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10793,7 +10793,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -11228,7 +11228,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -11248,7 +11248,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -11263,7 +11263,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12151,7 +12151,7 @@
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
@@ -12171,7 +12171,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -12253,7 +12253,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/core/src/BinaryFieldType/BinaryFieldType.js
+++ b/core/src/BinaryFieldType/BinaryFieldType.js
@@ -19,7 +19,7 @@ export class BinaryFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="color"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
         </label>

--- a/core/src/BinaryFieldType/BinaryFieldType.js
+++ b/core/src/BinaryFieldType/BinaryFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { ToggleButton } from "../ToggleButton";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./BinaryFieldType.less";
 export class BinaryFieldType extends Component {
@@ -13,17 +15,21 @@ export class BinaryFieldType extends Component {
   render() {
     return (
       <article className={cx(styles.BinaryFieldType, this.props.className)}>
-        <p className={styles.BinaryFieldTypeLabel}>
-          <label>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </label>
-        </p>
-        <p className={styles.Description}>{this.props.description}</p>
+        <label className={styles.BinaryFieldTypeLabel}>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="color"
+            tooltip={this.props.tooltip}
+          />
+        </label>
         <div className={styles.switch}>
           <ToggleButton {...this.props} onChange={this.onChange} />
           <span className={styles.slider} />
         </div>
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </article>
     );
   }

--- a/core/src/BinaryFieldType/BinaryFieldType.less
+++ b/core/src/BinaryFieldType/BinaryFieldType.less
@@ -11,7 +11,7 @@
     justify-content: space-between;
     align-items: end;
     margin-bottom: 3px;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
   }
   .Values {
     font-size: 1.2rem;

--- a/core/src/BinaryFieldType/BinaryFieldType.less
+++ b/core/src/BinaryFieldType/BinaryFieldType.less
@@ -11,7 +11,7 @@
     justify-content: space-between;
     align-items: end;
     margin-bottom: 3px;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
   }
   .Values {
     font-size: 1.2rem;

--- a/core/src/BinaryFieldType/BinaryFieldType.less
+++ b/core/src/BinaryFieldType/BinaryFieldType.less
@@ -11,7 +11,7 @@
     justify-content: space-between;
     align-items: end;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   .Values {
     font-size: 1.2rem;

--- a/core/src/Button/Button.less
+++ b/core/src/Button/Button.less
@@ -1,9 +1,12 @@
-@btnDefault: #404759;
-@btnDefaultText: #ffffff;
-@btnSave: #63a41e;
-@btnCancel: #a7afbf;
-@btnWarn: #9a2803;
-@btnAlt: #d26a25;
+@import "../typography.less";
+@import "../colors.less";
+
+@btnDefault: @zesty-gray;
+@btnDefaultText: @white;
+@btnSave: @zesty-green;
+@btnCancel: @zesty-light-gray;
+@btnWarn: @zesty-red;
+@btnAlt: @zesty-orange;
 @btnDisabled: rgba(26, 32, 44, 0.12);
 
 .Button {
@@ -16,8 +19,8 @@
   color: #ffffff;
   cursor: pointer;
   display: flex;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: @button-font-size;
+  font-weight: @button-weight;
   font-style: normal;
   font-stretch: normal;
   line-height: 24px;

--- a/core/src/ColorFieldType/ColorFieldType.js
+++ b/core/src/ColorFieldType/ColorFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { Input } from "../Input";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./ColorFieldType.less";
 export class ColorFieldType extends Component {
@@ -26,10 +28,13 @@ export class ColorFieldType extends Component {
   render() {
     return (
       <label className={cx(styles.ColorFieldType, this.props.className)}>
-        <span className={styles.ColorFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-        </span>
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="color"
+          tooltip={this.props.tooltip}
+        />
+
         <div className={styles.ColorFieldTypeInput}>
           <Input
             required={this.props.required}
@@ -40,6 +45,10 @@ export class ColorFieldType extends Component {
           />
           <i className={cx(styles.Icon, "fa fa-paint-brush")} />
         </div>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/ColorFieldType/ColorFieldType.js
+++ b/core/src/ColorFieldType/ColorFieldType.js
@@ -31,7 +31,7 @@ export class ColorFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="color"
+          tag={this.props.tag}
           tooltip={this.props.tooltip}
         />
 

--- a/core/src/ColorFieldType/ColorFieldType.less
+++ b/core/src/ColorFieldType/ColorFieldType.less
@@ -9,7 +9,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   .ColorFieldTypeInput {
     display: flex;

--- a/core/src/ColorFieldType/ColorFieldType.less
+++ b/core/src/ColorFieldType/ColorFieldType.less
@@ -9,7 +9,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
   }
   .ColorFieldTypeInput {
     display: flex;

--- a/core/src/ColorFieldType/ColorFieldType.less
+++ b/core/src/ColorFieldType/ColorFieldType.less
@@ -9,7 +9,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
   }
   .ColorFieldTypeInput {
     display: flex;

--- a/core/src/CurrencyFieldType/CurrencyFieldType.js
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 
 import { Input } from "../Input";
-import { Infotip } from "../Infotip";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 import { Select, Option } from "../Select";
 import { currencies } from "./currencies";
 
@@ -53,13 +54,12 @@ export class CurrencyFieldType extends Component {
     return (
       <label className={styles.CurrencyFieldType}>
         <div className={styles.CurrencyFieldTypeLabel}>
-          <span>
-            <Infotip
-              title={`View this value in different currencies based upon your locale "${window.navigator.language}"`}
-            />
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </span>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="currency"
+            tooltip={`View this value in different currencies based upon your locale "${window.navigator.language}"`}
+          />
           <span>
             {Number(this.state.value).toLocaleString(
               window.navigator.language,
@@ -104,6 +104,10 @@ export class CurrencyFieldType extends Component {
             value={this.state.value}
           />
         </div>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/CurrencyFieldType/CurrencyFieldType.js
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.js
@@ -57,7 +57,7 @@ export class CurrencyFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="currency"
+            tag={this.props.tag}
             tooltip={`View this value in different currencies based upon your locale "${window.navigator.language}"`}
           />
           <span>

--- a/core/src/CurrencyFieldType/CurrencyFieldType.less
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
     span {
       display: flex;
     }

--- a/core/src/CurrencyFieldType/CurrencyFieldType.less
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
     span {
       display: flex;
     }

--- a/core/src/CurrencyFieldType/CurrencyFieldType.less
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.less
@@ -1,4 +1,5 @@
 @import "../typography.less";
+@import "../colors.less";
 
 .CurrencyFieldType {
   display: flex;
@@ -20,9 +21,9 @@
     .SelectCurrency {
       width: 100px;
       span > span {
-        background: #5b667d;
-        color: #fff;
-        border: #5b667d;
+        background: @zesty-tab-blue;
+        color: @white;
+        border: @zesty-tab-blue;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
       }

--- a/core/src/CurrencyFieldType/CurrencyFieldType.less
+++ b/core/src/CurrencyFieldType/CurrencyFieldType.less
@@ -9,7 +9,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
     span {
       display: flex;
     }

--- a/core/src/DateFieldType/DateFieldType.js
+++ b/core/src/DateFieldType/DateFieldType.js
@@ -3,6 +3,8 @@ import cx from "classnames";
 
 import Flatpickr from "react-flatpickr";
 import confirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
+import { FieldDescription } from "../FieldDescription";
+import { FieldLabel } from "../FieldLabel";
 
 require("../flatpickr.css");
 
@@ -17,12 +19,11 @@ export class DateFieldType extends Component {
   render() {
     return (
       <label className={cx(styles.DateFieldType, this.props.className)}>
-        <p className={styles.DateFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="date"
+        />
 
         <span className={styles.DateFieldTypeInput}>
           {this.props.datatype === "datetime" ? (
@@ -55,6 +56,10 @@ export class DateFieldType extends Component {
           )}
           <i className={cx(styles.Icon, "fa fa-calendar")} />
         </span>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/DateFieldType/DateFieldType.js
+++ b/core/src/DateFieldType/DateFieldType.js
@@ -22,6 +22,7 @@ export class DateFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
+          tooltip={this.props.tooltip}
           fieldType="date"
         />
 

--- a/core/src/DateFieldType/DateFieldType.js
+++ b/core/src/DateFieldType/DateFieldType.js
@@ -23,7 +23,7 @@ export class DateFieldType extends Component {
           label={this.props.label}
           required={this.props.required}
           tooltip={this.props.tooltip}
-          fieldType="date"
+          tag={this.props.tag}
         />
 
         <span className={styles.DateFieldTypeInput}>

--- a/core/src/DateFieldType/DateFieldType.less
+++ b/core/src/DateFieldType/DateFieldType.less
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DateFieldType/DateFieldType.less
+++ b/core/src/DateFieldType/DateFieldType.less
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DateFieldType/DateFieldType.less
+++ b/core/src/DateFieldType/DateFieldType.less
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DateTimeFieldType/DateTimeFieldType.js
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.js
@@ -35,7 +35,7 @@ export class DateTimeFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="datetime"
+          tag={this.props.tag}
           tooltip={this.props.tooltip}
         />
 

--- a/core/src/DateTimeFieldType/DateTimeFieldType.js
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.js
@@ -36,6 +36,7 @@ export class DateTimeFieldType extends Component {
           label={this.props.label}
           required={this.props.required}
           fieldType="datetime"
+          tooltip={this.props.tooltip}
         />
 
         <span className={styles.DateFieldTypeInput}>

--- a/core/src/DateTimeFieldType/DateTimeFieldType.js
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import styles from "./DateTimeFieldType.less";
+import { FieldDescription } from "../FieldDescription";
+import { FieldLabel } from "../FieldLabel";
 // import 'react-datepicker/dist/react-datepicker-cssmodules.css'
 
 export class DateTimeFieldType extends Component {
@@ -30,12 +32,11 @@ export class DateTimeFieldType extends Component {
   render() {
     return (
       <label className={cx(styles.DateFieldType, this.props.className)}>
-        <p className={styles.DateFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="datetime"
+        />
 
         <span className={styles.DateFieldTypeInput}>
           <input
@@ -45,6 +46,10 @@ export class DateTimeFieldType extends Component {
           />
           <i className={cx(styles.Icon, "fa fa-calendar")} />
         </span>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/DateTimeFieldType/DateTimeFieldType.less
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.less
@@ -6,7 +6,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DateTimeFieldType/DateTimeFieldType.less
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.less
@@ -6,7 +6,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DateTimeFieldType/DateTimeFieldType.less
+++ b/core/src/DateTimeFieldType/DateTimeFieldType.less
@@ -6,7 +6,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/DropDownFieldType/DropDownFieldType.js
+++ b/core/src/DropDownFieldType/DropDownFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { Select, Option } from "../Select";
+import { FieldDescription } from "../FieldDescription";
+import { FieldLabel } from "../FieldLabel";
 
 import styles from "./DropDownFieldType.less";
 export class DropDownFieldType extends Component {
@@ -14,12 +16,11 @@ export class DropDownFieldType extends Component {
   render() {
     return (
       <label className={cx(styles.DropDownFieldType, this.props.className)}>
-        <p className={styles.DropDownFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="dropdown"
+        />
 
         <Select
           name={this.props.name}
@@ -37,6 +38,10 @@ export class DropDownFieldType extends Component {
                 return <Option key={i} {...opt} />;
               })}
         </Select>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/DropDownFieldType/DropDownFieldType.js
+++ b/core/src/DropDownFieldType/DropDownFieldType.js
@@ -19,7 +19,7 @@ export class DropDownFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="dropdown"
+          tag={this.props.tag}
           tooltip={this.props.tooltip}
         />
 

--- a/core/src/DropDownFieldType/DropDownFieldType.js
+++ b/core/src/DropDownFieldType/DropDownFieldType.js
@@ -20,6 +20,7 @@ export class DropDownFieldType extends Component {
           label={this.props.label}
           required={this.props.required}
           fieldType="dropdown"
+          tooltip={this.props.tooltip}
         />
 
         <Select

--- a/core/src/EditorFieldType/EditorFieldType.js
+++ b/core/src/EditorFieldType/EditorFieldType.js
@@ -123,7 +123,7 @@ export class EditorFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="rich text"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
           <Select

--- a/core/src/EditorFieldType/EditorFieldType.js
+++ b/core/src/EditorFieldType/EditorFieldType.js
@@ -8,6 +8,8 @@ import { MarkdownEditor } from "./Editors/Markdown.js";
 import { HtmlEditor } from "./Editors/Html.js";
 
 import { Select, Option } from "../Select";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./EditorFieldType.less";
 export class EditorFieldType extends Component {
@@ -118,13 +120,11 @@ export class EditorFieldType extends Component {
     return (
       <div className={cx(styles.EditorFieldType, this.props.className)}>
         <label className={styles.EditorFieldTypeLabel}>
-          <span>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </span>
-          <span>
-            {this.state.value.length || "0"}/{this.props.maxLength}
-          </span>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="rich text"
+          />
           <Select
             name="editorType"
             className={styles.EditorSelection}
@@ -137,8 +137,12 @@ export class EditorFieldType extends Component {
             <Option value="html" text="HTML" />
           </Select>
         </label>
-        <p className={styles.Description}>{this.props.description}</p>
+
         <div className={styles.EditorFieldTypePM}>{this.renderEditor()}</div>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </div>
     );
   }

--- a/core/src/EditorFieldType/EditorFieldType.js
+++ b/core/src/EditorFieldType/EditorFieldType.js
@@ -124,6 +124,7 @@ export class EditorFieldType extends Component {
             label={this.props.label}
             required={this.props.required}
             fieldType="rich text"
+            tooltip={this.props.tooltip}
           />
           <Select
             name="editorType"

--- a/core/src/EditorFieldType/EditorFieldType.less
+++ b/core/src/EditorFieldType/EditorFieldType.less
@@ -5,7 +5,7 @@
     display: flex;
     margin-bottom: 3px;
     align-items: flex-end;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
 
     & span:first-child {
       flex: 1;

--- a/core/src/EditorFieldType/EditorFieldType.less
+++ b/core/src/EditorFieldType/EditorFieldType.less
@@ -5,7 +5,7 @@
     display: flex;
     margin-bottom: 3px;
     align-items: flex-end;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
 
     & span:first-child {
       flex: 1;

--- a/core/src/EditorFieldType/EditorFieldType.less
+++ b/core/src/EditorFieldType/EditorFieldType.less
@@ -12,7 +12,7 @@
     }
 
     .EditorSelection {
-      margin-left: 10px;
+      margin-left: auto;
       min-width: 150px;
       // height: 30px;
     }

--- a/core/src/EditorFieldType/EditorFieldType.less
+++ b/core/src/EditorFieldType/EditorFieldType.less
@@ -5,7 +5,7 @@
     display: flex;
     margin-bottom: 3px;
     align-items: flex-end;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
 
     & span:first-child {
       flex: 1;

--- a/core/src/FieldDescription/FieldDescription.js
+++ b/core/src/FieldDescription/FieldDescription.js
@@ -1,0 +1,7 @@
+import React from "react";
+import styles from "./FieldDescription.less";
+import cx from "classnames";
+
+export function FieldDescription(props) {
+  return <p className={styles.Description}>{props.description}</p>;
+}

--- a/core/src/FieldDescription/FieldDescription.less
+++ b/core/src/FieldDescription/FieldDescription.less
@@ -5,7 +5,7 @@
   font-size: @helperTextFontSize;
   font-family: @secondaryFont;
   color: @zesty-light-gray;
-  padding-top: 4px;
-  padding-left: 2px;
+  padding-top: 5px;
+  margin-left: 3px;
   text-align: left;
 }

--- a/core/src/FieldDescription/FieldDescription.less
+++ b/core/src/FieldDescription/FieldDescription.less
@@ -2,8 +2,8 @@
 @import "../typography.less";
 
 .Description {
-  font-size: @helperTextFontSize;
-  font-family: @secondaryFont;
+  font-size: @helper-text-font-size;
+  font-family: @secondary-font;
   color: @zesty-light-gray;
   padding-top: 5px;
   margin-left: 3px;

--- a/core/src/FieldDescription/FieldDescription.less
+++ b/core/src/FieldDescription/FieldDescription.less
@@ -1,0 +1,11 @@
+@import "../colors.less";
+@import "../typography.less";
+
+.Description {
+  font-size: @helperTextFontSize;
+  font-family: @secondaryFont;
+  color: @zesty-light-gray;
+  padding-top: 4px;
+  padding-left: 2px;
+  text-align: left;
+}

--- a/core/src/FieldDescription/index.js
+++ b/core/src/FieldDescription/index.js
@@ -1,0 +1,1 @@
+export { FieldDescription } from "./FieldDescription";

--- a/core/src/FieldLabel/FieldLabel.js
+++ b/core/src/FieldLabel/FieldLabel.js
@@ -1,0 +1,22 @@
+import React from "react";
+import styles from "./FieldLabel.less";
+import cx from "classnames";
+
+export function FieldLabel(props) {
+  return (
+    <p className={styles.TextFieldTypeLabel}>
+      <span>
+        {props.label}
+        {props.required && <span className={styles.TextFieldRequired}>*</span>}
+        {props.fieldType && (
+          <span className={styles.TextFieldType}>{props.fieldType}</span>
+        )}
+      </span>
+      {props.maxLength && (
+        <span className={styles.ValidationLimitHelper}>
+          {props.valueLength}/{props.maxLength}
+        </span>
+      )}
+    </p>
+  );
+}

--- a/core/src/FieldLabel/FieldLabel.js
+++ b/core/src/FieldLabel/FieldLabel.js
@@ -7,14 +7,13 @@ export function FieldLabel(props) {
   return (
     <p className={styles.TextFieldTypeLabel}>
       <span>
-        {props.label}
-        {props.required && <span className={styles.TextFieldRequired}>*</span>}
         {props.tooltip && (
           <Infotip className={styles.ToolTip} title={props.tooltip} />
         )}
-        {props.fieldType && (
-          <span className={styles.TextFieldType}>{props.fieldType}</span>
-        )}
+        {props.label}
+        {props.required && <span className={styles.TextFieldRequired}>*</span>}
+
+        {props.tag && <span className={styles.Tag}>{props.tag}</span>}
       </span>
       {props.maxLength && (
         <span className={styles.ValidationLimitHelper}>

--- a/core/src/FieldLabel/FieldLabel.js
+++ b/core/src/FieldLabel/FieldLabel.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "./FieldLabel.less";
 import cx from "classnames";
+import { Infotip } from "../Infotip";
 
 export function FieldLabel(props) {
   return (
@@ -8,6 +9,9 @@ export function FieldLabel(props) {
       <span>
         {props.label}
         {props.required && <span className={styles.TextFieldRequired}>*</span>}
+        {props.tooltip && (
+          <Infotip className={styles.ToolTip} title={props.tooltip} />
+        )}
         {props.fieldType && (
           <span className={styles.TextFieldType}>{props.fieldType}</span>
         )}

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -19,7 +19,7 @@
     font-family: @secondaryFont;
     color: @zesty-light-gray;
   }
-  .TextFieldType {
+  .Tag {
     color: @zesty-light-blue;
     margin-left: 10px;
     padding: 1px 3px 1px 4px;

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -31,4 +31,8 @@
     background: @white;
     border-radius: 3px;
   }
+
+  .ToolTip {
+    margin-left: 4px;
+  }
 }

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -21,9 +21,14 @@
   }
   .TextFieldType {
     color: @zesty-light-blue;
-    padding-left: 10px;
+    margin-left: 10px;
+    padding: 1px 3px 1px 4px;
+    font-family: @secondaryFont;
     font-size: 9px;
-    top: -2px;
+    top: -1px;
     position: relative;
+    border: lighten(@zesty-light-blue, 10%) 1px solid;
+    background: @white;
+    border-radius: 3px;
   }
 }

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -5,7 +5,7 @@
   display: flex;
   justify-content: space-between;
   align-items: end;
-  font-size: @FieldLabelSize;
+  font-size: @fieldLabelSize;
   line-height: @labelLineHeight;
   letter-spacing: 0.3;
   color: @zesty-dark-blue;

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -1,0 +1,29 @@
+@import "../colors.less";
+@import "../typography.less";
+
+.TextFieldTypeLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  font-size: @FieldLabelSize;
+  line-height: @labelLineHeight;
+  letter-spacing: 0.5;
+  color: @zesty-dark-blue;
+  padding-bottom: 3px;
+  .TextFieldRequired {
+    color: @zesty-red;
+    padding-left: 3px;
+  }
+  .ValidationLimitHelper {
+    font-size: @helperTextFontSize;
+    font-family: @secondaryFont;
+    color: @zesty-light-gray;
+  }
+  .TextFieldType {
+    color: @zesty-light-blue;
+    padding-left: 10px;
+    font-size: 9px;
+    top: -2px;
+    position: relative;
+  }
+}

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -7,7 +7,7 @@
   align-items: end;
   font-size: @FieldLabelSize;
   line-height: @labelLineHeight;
-  letter-spacing: 0.5;
+  letter-spacing: 0.3;
   color: @zesty-dark-blue;
   padding-bottom: 3px;
   .TextFieldRequired {

--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -5,8 +5,8 @@
   display: flex;
   justify-content: space-between;
   align-items: end;
-  font-size: @fieldLabelSize;
-  line-height: @labelLineHeight;
+  font-size: @field-label-size;
+  line-height: @label-line-height;
   letter-spacing: 0.3;
   color: @zesty-dark-blue;
   padding-bottom: 3px;
@@ -15,15 +15,15 @@
     padding-left: 3px;
   }
   .ValidationLimitHelper {
-    font-size: @helperTextFontSize;
-    font-family: @secondaryFont;
+    font-size: @helper-text-font-size;
+    font-family: @secondary-font;
     color: @zesty-light-gray;
   }
   .Tag {
     color: @zesty-light-blue;
     margin-left: 10px;
     padding: 1px 3px 1px 4px;
-    font-family: @secondaryFont;
+    font-family: @secondary-font;
     font-size: 9px;
     top: -1px;
     position: relative;

--- a/core/src/FieldLabel/index.js
+++ b/core/src/FieldLabel/index.js
@@ -1,0 +1,1 @@
+export { FieldLabel } from "./FieldLabel";

--- a/core/src/ImageFieldType/ImageFieldType.js
+++ b/core/src/ImageFieldType/ImageFieldType.js
@@ -49,7 +49,7 @@ export class ImageFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="image"
+            tag={this.props.tag}
             maxLength={maxImages}
             valueLength={imageCount}
             tooltip={this.props.tooltip}

--- a/core/src/ImageFieldType/ImageFieldType.js
+++ b/core/src/ImageFieldType/ImageFieldType.js
@@ -52,6 +52,7 @@ export class ImageFieldType extends Component {
             fieldType="image"
             maxLength={maxImages}
             valueLength={imageCount}
+            tooltip={this.props.tooltip}
           />
         </label>
 

--- a/core/src/ImageFieldType/ImageFieldType.js
+++ b/core/src/ImageFieldType/ImageFieldType.js
@@ -2,6 +2,8 @@ import React, { Component, Fragment } from "react";
 import cx from "classnames";
 import { Card, CardContent } from "../Card";
 import { Button } from "../Button";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 import styles from "./ImageFieldType.less";
 
 export class ImageFieldType extends Component {
@@ -43,11 +45,15 @@ export class ImageFieldType extends Component {
 
     return (
       <Fragment>
-        <label className={styles.ImageFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
+        <label htmlFor={this.props.name}>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="image"
+            maxLength={maxImages}
+            valueLength={imageCount}
+          />
         </label>
-        <p className={styles.Description}>{this.props.description}</p>
 
         {imageCount > maxImages && (
           <p className={styles.WarningMsg}>
@@ -89,6 +95,10 @@ export class ImageFieldType extends Component {
               ))}
           </CardContent>
         </Card>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </Fragment>
     );
   }

--- a/core/src/ImageFieldType/ImageFieldType.less
+++ b/core/src/ImageFieldType/ImageFieldType.less
@@ -35,7 +35,7 @@
 }
 
 .ImageFieldTypeLabel {
-  font-size: @labelTextSize;
+  font-size: @FieldLabelSize;
 }
 
 .warn {

--- a/core/src/ImageFieldType/ImageFieldType.less
+++ b/core/src/ImageFieldType/ImageFieldType.less
@@ -35,7 +35,7 @@
 }
 
 .ImageFieldTypeLabel {
-  font-size: @FieldLabelSize;
+  font-size: @fieldLabelSize;
 }
 
 .warn {

--- a/core/src/ImageFieldType/ImageFieldType.less
+++ b/core/src/ImageFieldType/ImageFieldType.less
@@ -35,7 +35,7 @@
 }
 
 .ImageFieldTypeLabel {
-  font-size: @fieldLabelSize;
+  font-size: @field-label-size;
 }
 
 .warn {

--- a/core/src/Infotip/Infotip.js
+++ b/core/src/Infotip/Infotip.js
@@ -4,7 +4,7 @@ import cx from "classnames";
 
 export function Infotip(props) {
   return (
-    <div className={styles.tip}>
+    <span className={styles.tip}>
       <i
         className={cx(styles.tipIcon, "fa fa-question-circle")}
         aria-hidden="true"
@@ -13,6 +13,6 @@ export function Infotip(props) {
         {props.children}
         {props.title}
       </p>
-    </div>
+    </span>
   );
 }

--- a/core/src/Infotip/Infotip.less
+++ b/core/src/Infotip/Infotip.less
@@ -38,7 +38,7 @@
       position: absolute;
       background: @zesty-dark-blue;
       color: @white;
-      font-family: @secondaryFont;
+      font-family: @secondary-font;
       padding: 15px 23px;
       width: 25rem;
       line-height: 20px;

--- a/core/src/Infotip/Infotip.less
+++ b/core/src/Infotip/Infotip.less
@@ -5,7 +5,6 @@
   cursor: help;
   position: relative;
   font-size: 14px;
-  margin-left: 4px;
 
   .tipIcon {
     color: @zesty-tab-blue;

--- a/core/src/Infotip/Infotip.less
+++ b/core/src/Infotip/Infotip.less
@@ -1,9 +1,10 @@
 @import "../colors.less";
+@import "../typography.less";
 
 .tip {
   cursor: help;
   position: relative;
-  font-size: 16px;
+  font-size: 14px;
   margin-left: 4px;
 
   .tipIcon {
@@ -37,8 +38,9 @@
       display: block;
       position: absolute;
       background: @zesty-dark-blue;
-      color: @zesty-field-blue;
-      padding: 10px 10px 10px 30px;
+      color: @white;
+      font-family: @secondaryFont;
+      padding: 15px 23px;
       width: 25rem;
       line-height: 20px;
       bottom: 26px;
@@ -46,6 +48,7 @@
       left: -7px;
       z-index: 10;
       overflow-wrap: break-word;
+      box-shadow: 0px 0px 15px rgba(10px, -10px, 0, 0.2);
     }
   }
 }

--- a/core/src/Infotip/Infotip.less
+++ b/core/src/Infotip/Infotip.less
@@ -4,6 +4,7 @@
   cursor: help;
   position: relative;
   font-size: 16px;
+  margin-left: 4px;
 
   .tipIcon {
     color: @zesty-tab-blue;

--- a/core/src/Input/Input.less
+++ b/core/src/Input/Input.less
@@ -23,26 +23,6 @@
     border: solid 1px @zesty-tab-blue;
   }
 
-  &:placeholder-shown {
-    color: @zesty-dark-blue;
-  }
-  &::-webkit-input-placeholder {
-    /* Chrome/Opera/Safari */
-    color: @zesty-light-gray;
-  }
-  &::-moz-placeholder {
-    /* Firefox 19+ */
-    color: @zesty-light-gray;
-  }
-  &:-ms-input-placeholder {
-    /* IE 10+ */
-    color: @zesty-light-gray;
-  }
-  &:-moz-placeholder {
-    /* Firefox 18- */
-    color: @zesty-light-gray;
-  }
-
   &:disabled {
     background-color: rgba(0, 0, 0, 0.06);
     opacity: 0.4;

--- a/core/src/Input/Input.less
+++ b/core/src/Input/Input.less
@@ -9,8 +9,8 @@
   display: block;
   padding: 8px 12px;
 
-  font-family: @inputFont;
-  font-size: @inputFontSize;
+  font-family: @input-font;
+  font-size: @input-font-size;
   font-weight: 400;
   line-height: 24px;
   letter-spacing: 0px;

--- a/core/src/Input/Input.less
+++ b/core/src/Input/Input.less
@@ -1,14 +1,16 @@
+@import "../typography.less";
 @import "../colors.less";
+
 .Input {
   background-color: @white;
   border-radius: 3px;
   border: solid 1px rgba(0, 0, 0, 0.12);
-  color: #1a202c;
+  color: @zesty-dark-blue;
   display: block;
   padding: 8px 12px;
 
-  font-family: Verdana, Arial, sans-serif;
-  font-size: 16px;
+  font-family: @inputFont;
+  font-size: @inputFontSize;
   font-weight: 400;
   line-height: 24px;
   letter-spacing: 0px;
@@ -16,13 +18,29 @@
   &:hover,
   &:active,
   &:focus {
-    color: #1a202c;
+    color: @zesty-dark-blue;
     outline: none;
-    border: solid 1px #4f596d;
+    border: solid 1px @zesty-tab-blue;
   }
 
   &:placeholder-shown {
-    color: #1a202c;
+    color: @zesty-dark-blue;
+  }
+  &::-webkit-input-placeholder {
+    /* Chrome/Opera/Safari */
+    color: @zesty-light-gray;
+  }
+  &::-moz-placeholder {
+    /* Firefox 19+ */
+    color: @zesty-light-gray;
+  }
+  &:-ms-input-placeholder {
+    /* IE 10+ */
+    color: @zesty-light-gray;
+  }
+  &:-moz-placeholder {
+    /* Firefox 18- */
+    color: @zesty-light-gray;
   }
 
   &:disabled {
@@ -41,7 +59,7 @@
 
   &:focus:required:invalid,
   &.error {
-    border: solid 1px #9a2803;
+    border: solid 1px @zesty-red;
   }
 }
 .ErrorMsg {

--- a/core/src/InternalLinkFieldType/InternalLinkFieldType.js
+++ b/core/src/InternalLinkFieldType/InternalLinkFieldType.js
@@ -32,6 +32,7 @@ export class InternalLinkFieldType extends Component {
             label={this.props.label}
             required={this.props.required}
             fieldType="internal link"
+            tooltip={this.props.tooltip}
           />
         </label>
 

--- a/core/src/InternalLinkFieldType/InternalLinkFieldType.js
+++ b/core/src/InternalLinkFieldType/InternalLinkFieldType.js
@@ -31,7 +31,7 @@ export class InternalLinkFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="internal link"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
         </label>

--- a/core/src/InternalLinkFieldType/InternalLinkFieldType.js
+++ b/core/src/InternalLinkFieldType/InternalLinkFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import debounce from "lodash.debounce";
 
 import { Select, Option } from "../Select";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./InternalLinkFieldType.less";
 export class InternalLinkFieldType extends Component {
@@ -25,13 +27,13 @@ export class InternalLinkFieldType extends Component {
   render() {
     return (
       <article className={this.props.className}>
-        <div>
-          <label className={styles.InternalLinkFieldTypeLabel}>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </label>
-          <p className={styles.Description}>{this.props.description}</p>
-        </div>
+        <label htmlFor={this.props.name}>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="internal link"
+          />
+        </label>
 
         <Select
           name={this.props.name}
@@ -54,6 +56,10 @@ export class InternalLinkFieldType extends Component {
             return <Option key={i} {...option} />;
           })}
         </Select>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </article>
     );
   }

--- a/core/src/InternalLinkFieldType/InternalLinkFieldType.less
+++ b/core/src/InternalLinkFieldType/InternalLinkFieldType.less
@@ -5,5 +5,5 @@
 }
 
 .InternalLinkFieldTypeLabel {
-  font-size: @labelTextSize;
+  font-size: @FieldLabelSize;
 }

--- a/core/src/InternalLinkFieldType/InternalLinkFieldType.less
+++ b/core/src/InternalLinkFieldType/InternalLinkFieldType.less
@@ -3,7 +3,3 @@
 .InternalLinkFieldType {
   display: flex;
 }
-
-.InternalLinkFieldTypeLabel {
-  font-size: @FieldLabelSize;
-}

--- a/core/src/NumberFieldType/NumberFieldType.js
+++ b/core/src/NumberFieldType/NumberFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { Input } from "../Input";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./NumberFieldType.less";
 export class NumberFieldType extends Component {
@@ -28,12 +30,11 @@ export class NumberFieldType extends Component {
   render() {
     return (
       <label className={cx(styles.NumberFieldType, this.props.className)}>
-        <p className={styles.NumberFieldTypeLabel}>
-          {this.props.label}
-          {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="number"
+        />
 
         <Input
           type="number"
@@ -41,6 +42,10 @@ export class NumberFieldType extends Component {
           onChange={this.onChange}
           value={this.state.number}
         />
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/NumberFieldType/NumberFieldType.js
+++ b/core/src/NumberFieldType/NumberFieldType.js
@@ -33,7 +33,7 @@ export class NumberFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="number"
+          tag={this.props.tag}
           tooltip={this.props.tooltip}
         />
 

--- a/core/src/NumberFieldType/NumberFieldType.js
+++ b/core/src/NumberFieldType/NumberFieldType.js
@@ -34,6 +34,7 @@ export class NumberFieldType extends Component {
           label={this.props.label}
           required={this.props.required}
           fieldType="number"
+          tooltip={this.props.tooltip}
         />
 
         <Input

--- a/core/src/NumberFieldType/NumberFieldType.less
+++ b/core/src/NumberFieldType/NumberFieldType.less
@@ -8,7 +8,7 @@
     display: flex;
     // justify-content: space-between;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   input {
     display: block;

--- a/core/src/NumberFieldType/NumberFieldType.less
+++ b/core/src/NumberFieldType/NumberFieldType.less
@@ -4,12 +4,6 @@
   display: flex;
   flex-direction: column;
   max-width: 300px;
-  .NumberFieldTypeLabel {
-    display: flex;
-    // justify-content: space-between;
-    margin-bottom: 3px;
-    font-size: @FieldLabelSize;
-  }
   input {
     display: block;
   }
@@ -17,6 +11,6 @@
 
 .NumberFieldType.Error {
   input {
-    border: solid 1px #9a2803;
+    border: solid 1px @zesty-red;
   }
 }

--- a/core/src/OneToManyFieldType/OneToManyFieldType.js
+++ b/core/src/OneToManyFieldType/OneToManyFieldType.js
@@ -123,6 +123,7 @@ export class OneToManyFieldType extends Component {
             label={this.props.label}
             required={this.props.required}
             fieldType="one to many relationship"
+            tooltip={this.props.tooltip}
           />
         </label>
 

--- a/core/src/OneToManyFieldType/OneToManyFieldType.js
+++ b/core/src/OneToManyFieldType/OneToManyFieldType.js
@@ -122,7 +122,7 @@ export class OneToManyFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="one to many relationship"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
         </label>

--- a/core/src/OneToManyFieldType/OneToManyFieldType.js
+++ b/core/src/OneToManyFieldType/OneToManyFieldType.js
@@ -3,6 +3,8 @@ import React, { Component, Fragment } from "react";
 import { Tag } from "../Tag";
 import { Loader } from "../Loader";
 import { Select, Option } from "../Select";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./OneToManyFieldType.less";
 export class OneToManyFieldType extends Component {
@@ -116,14 +118,13 @@ export class OneToManyFieldType extends Component {
   render() {
     return (
       <Fragment>
-        <p>
-          <label className={styles.OneToManyFieldTypeLabel}>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </label>
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <label htmlFor={this.props.name}>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="one to many relationship"
+          />
+        </label>
 
         <section className={styles.OneToMany}>
           <Select
@@ -160,6 +161,9 @@ export class OneToManyFieldType extends Component {
             )}
           </article>
         </section>
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </Fragment>
     );
   }

--- a/core/src/OneToManyFieldType/OneToManyFieldType.less
+++ b/core/src/OneToManyFieldType/OneToManyFieldType.less
@@ -20,7 +20,3 @@
     }
   }
 }
-
-.OneToManyFieldTypeLabel {
-  font-size: @FieldLabelSize;
-}

--- a/core/src/OneToManyFieldType/OneToManyFieldType.less
+++ b/core/src/OneToManyFieldType/OneToManyFieldType.less
@@ -22,5 +22,5 @@
 }
 
 .OneToManyFieldTypeLabel {
-  font-size: @labelTextSize;
+  font-size: @FieldLabelSize;
 }

--- a/core/src/OneToOneFieldType/OneToOneFieldType.js
+++ b/core/src/OneToOneFieldType/OneToOneFieldType.js
@@ -43,6 +43,7 @@ export class OneToOneFieldType extends Component {
             label={this.props.label}
             required={this.props.required}
             fieldType="one to one relationship"
+            tooltip={this.props.tooltip}
           />
         </label>
 

--- a/core/src/OneToOneFieldType/OneToOneFieldType.js
+++ b/core/src/OneToOneFieldType/OneToOneFieldType.js
@@ -42,7 +42,7 @@ export class OneToOneFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="one to one relationship"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
         </label>

--- a/core/src/OneToOneFieldType/OneToOneFieldType.js
+++ b/core/src/OneToOneFieldType/OneToOneFieldType.js
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 import { Select, Option } from "../Select";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./OneToOneFieldType.less";
 
@@ -36,14 +38,13 @@ export class OneToOneFieldType extends Component {
   render() {
     return (
       <article className={this.props.className}>
-        <p>
-          <label className={styles.OneToOneFieldTypeLabel}>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </label>
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <label htmlFor={this.props.name}>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="one to one relationship"
+          />
+        </label>
 
         <Select
           name={this.props.name}
@@ -62,6 +63,10 @@ export class OneToOneFieldType extends Component {
                 return <Option key={i} {...opt} />;
               })}
         </Select>
+
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </article>
     );
   }

--- a/core/src/OneToOneFieldType/OneToOneFieldType.less
+++ b/core/src/OneToOneFieldType/OneToOneFieldType.less
@@ -5,5 +5,5 @@
 }
 
 .OneToOneFieldTypeLabel {
-  font-size: @labelTextSize;
+  font-size: @FieldLabelSize;
 }

--- a/core/src/OneToOneFieldType/OneToOneFieldType.less
+++ b/core/src/OneToOneFieldType/OneToOneFieldType.less
@@ -3,7 +3,3 @@
 .OneToOneFieldType {
   display: flex;
 }
-
-.OneToOneFieldTypeLabel {
-  font-size: @FieldLabelSize;
-}

--- a/core/src/Select/Select.less
+++ b/core/src/Select/Select.less
@@ -1,4 +1,5 @@
 @import "../colors.less";
+@import "../typography.less";
 
 .selector {
   cursor: pointer;
@@ -64,11 +65,11 @@
       display: block;
       flex: 1;
       overflow: hidden;
-      padding: 8px 12px;
+      padding: 7px 8px 6px 10px;
       text-overflow: ellipsis;
 
       font-family: Verdana, Arial, sans-serif;
-      font-size: 16px;
+      font-size: 12px;
       font-weight: 400;
       line-height: 24px;
       letter-spacing: 0px;
@@ -137,12 +138,12 @@
     // }
 
     li {
-      color: #1a202c;
+      color: @zesty-dark-blue;
       cursor: pointer;
       padding: 8px 16px;
 
       font-family: Verdana, Arial, sans-serif;
-      font-size: 16px;
+      font-size: 12px;
       font-weight: 400;
       line-height: 24px;
       letter-spacing: 0px;

--- a/core/src/SortFieldType/SortFieldType.js
+++ b/core/src/SortFieldType/SortFieldType.js
@@ -46,7 +46,7 @@ export class SortFieldType extends Component {
           <FieldLabel
             label={this.props.label}
             required={this.props.required}
-            fieldType="sort"
+            tag={this.props.tag}
             tooltip={this.props.tooltip}
           />
         </label>

--- a/core/src/SortFieldType/SortFieldType.js
+++ b/core/src/SortFieldType/SortFieldType.js
@@ -47,6 +47,7 @@ export class SortFieldType extends Component {
             label={this.props.label}
             required={this.props.required}
             fieldType="sort"
+            tooltip={this.props.tooltip}
           />
         </label>
 

--- a/core/src/SortFieldType/SortFieldType.js
+++ b/core/src/SortFieldType/SortFieldType.js
@@ -3,6 +3,8 @@ import cx from "classnames";
 
 import { Input } from "../Input";
 import { Button } from "../Button";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./SortFieldType.less";
 export class SortFieldType extends Component {
@@ -42,8 +44,10 @@ export class SortFieldType extends Component {
       <article className={cx(styles.SortFieldType, this.props.className)}>
         <section className={styles.SortFieldTypeLabel}>
           <label>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
+            <FieldLabel
+              label={this.props.label}
+              required={this.props.required}
+            />
           </label>
         </section>
         <section className={styles.Sort}>
@@ -67,6 +71,9 @@ export class SortFieldType extends Component {
             <i className="fa fa-minus" />
           </Button>
         </section>
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </article>
     );
   }

--- a/core/src/SortFieldType/SortFieldType.js
+++ b/core/src/SortFieldType/SortFieldType.js
@@ -42,15 +42,14 @@ export class SortFieldType extends Component {
   render() {
     return (
       <article className={cx(styles.SortFieldType, this.props.className)}>
-        <section className={styles.SortFieldTypeLabel}>
-          <label>
-            <FieldLabel
-              label={this.props.label}
-              required={this.props.required}
-              fieldType="sort"
-            />
-          </label>
-        </section>
+        <label>
+          <FieldLabel
+            label={this.props.label}
+            required={this.props.required}
+            fieldType="sort"
+          />
+        </label>
+
         <section className={styles.Sort}>
           <Button
             className={cx(styles.Increment, styles.Left)}

--- a/core/src/SortFieldType/SortFieldType.js
+++ b/core/src/SortFieldType/SortFieldType.js
@@ -47,6 +47,7 @@ export class SortFieldType extends Component {
             <FieldLabel
               label={this.props.label}
               required={this.props.required}
+              fieldType="sort"
             />
           </label>
         </section>

--- a/core/src/SortFieldType/SortFieldType.less
+++ b/core/src/SortFieldType/SortFieldType.less
@@ -24,7 +24,7 @@
     }
 
     input {
-      width: 80px;
+      width: 60px;
       border-radius: 0px;
       text-align: center;
       border-left: none;

--- a/core/src/SortFieldType/SortFieldType.less
+++ b/core/src/SortFieldType/SortFieldType.less
@@ -7,7 +7,7 @@
   .SortFieldTypeLabel {
     display: flex;
     margin-bottom: 3px;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
   }
   .Sort {
     display: flex;

--- a/core/src/SortFieldType/SortFieldType.less
+++ b/core/src/SortFieldType/SortFieldType.less
@@ -4,18 +4,14 @@
 .SortFieldType {
   display: flex;
   flex-direction: column;
-  .SortFieldTypeLabel {
-    display: flex;
-    margin-bottom: 3px;
-    font-size: @FieldLabelSize;
-  }
+
   .Sort {
     display: flex;
     align-items: center;
 
     .Increment {
       width: 40px;
-      height: 40px;
+      height: 42px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -28,8 +24,11 @@
     }
 
     input {
-      width: 50px;
+      width: 80px;
       border-radius: 0px;
+      text-align: center;
+      border-left: none;
+      border-right: none;
     }
   }
 }

--- a/core/src/TextFieldType/TextFieldType.js
+++ b/core/src/TextFieldType/TextFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { Input } from "../Input";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./TextFieldType.less";
 export class TextFieldType extends Component {
@@ -33,16 +35,13 @@ export class TextFieldType extends Component {
           valueLength > maxLength ? styles.Error : ""
         )}
       >
-        <p className={styles.TextFieldTypeLabel}>
-          <span>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </span>
-          <span>
-            {valueLength}/{maxLength}
-          </span>
-        </p>
-
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="text"
+          maxLength={maxLength}
+          valueLength={valueLength}
+        />
         <Input
           type="text"
           name={this.props.name}
@@ -59,7 +58,7 @@ export class TextFieldType extends Component {
             Your input is over the specified limit
           </span>
         )}
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldDescription description={this.props.description} />
       </label>
     );
   }

--- a/core/src/TextFieldType/TextFieldType.js
+++ b/core/src/TextFieldType/TextFieldType.js
@@ -43,8 +43,6 @@ export class TextFieldType extends Component {
           </span>
         </p>
 
-        <p className={styles.Description}>{this.props.description}</p>
-
         <Input
           type="text"
           name={this.props.name}
@@ -61,6 +59,7 @@ export class TextFieldType extends Component {
             Your input is over the specified limit
           </span>
         )}
+        <p className={styles.Description}>{this.props.description}</p>
       </label>
     );
   }

--- a/core/src/TextFieldType/TextFieldType.js
+++ b/core/src/TextFieldType/TextFieldType.js
@@ -38,7 +38,7 @@ export class TextFieldType extends Component {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="text"
+          tag={this.props.tag}
           maxLength={maxLength}
           valueLength={valueLength}
           tooltip={this.props.tooltip}

--- a/core/src/TextFieldType/TextFieldType.js
+++ b/core/src/TextFieldType/TextFieldType.js
@@ -41,6 +41,7 @@ export class TextFieldType extends Component {
           fieldType="text"
           maxLength={maxLength}
           valueLength={valueLength}
+          tooltip={this.props.tooltip}
         />
         <Input
           type="text"

--- a/core/src/TextFieldType/TextFieldType.less
+++ b/core/src/TextFieldType/TextFieldType.less
@@ -1,4 +1,5 @@
 @import "../typography.less";
+@import "../colors.less";
 
 .TextFieldType {
   display: flex;
@@ -12,6 +13,11 @@
     line-height: 24px;
     color: #1a202c;
   }
+}
+
+.Description {
+  font-size: 9px;
+  color: @zesty-light-grey;
 }
 
 .TextFieldType.Error {

--- a/core/src/TextFieldType/TextFieldType.less
+++ b/core/src/TextFieldType/TextFieldType.less
@@ -4,25 +4,11 @@
 .TextFieldType {
   display: flex;
   flex-direction: column;
-
-  .TextFieldTypeLabel {
-    display: flex;
-    justify-content: space-between;
-    align-items: end;
-    font-size: @labelTextSize;
-    line-height: 24px;
-    color: #1a202c;
-  }
-}
-
-.Description {
-  font-size: 9px;
-  color: @zesty-light-grey;
 }
 
 .TextFieldType.Error {
   input {
-    border: solid 1px #9a2803;
+    border: solid 1px @zesty-red;
   }
 }
 .ErrorDescription {
@@ -30,5 +16,5 @@
   font-size: 12px;
   line-height: 1.33;
   letter-spacing: normal;
-  color: #9a2803;
+  color: @zesty-red;
 }

--- a/core/src/Textarea/Textarea.less
+++ b/core/src/Textarea/Textarea.less
@@ -10,8 +10,8 @@
   background-color: @white;
   color: @zesty-dark-blue;
 
-  font-family: @inputFont;
-  font-size: @inputFontSize;
+  font-family: @input-font;
+  font-size: @input-font-size;
   font-weight: 400;
   line-height: 20px;
   letter-spacing: 0px;

--- a/core/src/Textarea/Textarea.less
+++ b/core/src/Textarea/Textarea.less
@@ -1,36 +1,53 @@
 @import "../colors.less";
+@import "../typography.less";
+
 .Textarea {
   min-height: 100px;
   min-width: 30rem;
 
   border-radius: 3px;
   border: solid 1px rgba(26, 32, 44, 0.12);
-  background-color: #ffffff;
-  color: #1a202c;
+  background-color: @white;
+  color: @zesty-dark-blue;
 
-  font-family: Verdana, Arial, sans-serif;
-  font-size: 16px;
+  font-family: @inputFont;
+  font-size: @inputFontSize;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 20px;
   letter-spacing: 0px;
-
-  padding: 8px 12px;
+  padding: 6px 10px;
 
   &:hover,
   &:active,
   &:focus {
-    border: solid 1px #4f596d;
+    border: solid 1px @zesty-tab-blue;
     outline: none;
     box-shadow: none;
   }
   &:placeholder-shown {
     opacity: 0.4;
   }
+  &::-webkit-input-placeholder {
+    /* Chrome/Opera/Safari */
+    color: @zesty-light-gray;
+  }
+  &::-moz-placeholder {
+    /* Firefox 19+ */
+    color: @zesty-light-gray;
+  }
+  &:-ms-input-placeholder {
+    /* IE 10+ */
+    color: @zesty-light-gray;
+  }
+  &:-moz-placeholder {
+    /* Firefox 18- */
+    color: @zesty-light-gray;
+  }
 
   // &:required {
   //   border: solid 1px #d81f0f;
   // }
   &:focus:required:invalid {
-    border: solid 1px #d81f0f;
+    border: solid 1px @zesty-red;
   }
 }

--- a/core/src/Textarea/Textarea.less
+++ b/core/src/Textarea/Textarea.less
@@ -24,25 +24,6 @@
     outline: none;
     box-shadow: none;
   }
-  &:placeholder-shown {
-    opacity: 0.4;
-  }
-  &::-webkit-input-placeholder {
-    /* Chrome/Opera/Safari */
-    color: @zesty-light-gray;
-  }
-  &::-moz-placeholder {
-    /* Firefox 19+ */
-    color: @zesty-light-gray;
-  }
-  &:-ms-input-placeholder {
-    /* IE 10+ */
-    color: @zesty-light-gray;
-  }
-  &:-moz-placeholder {
-    /* Firefox 18- */
-    color: @zesty-light-gray;
-  }
 
   // &:required {
   //   border: solid 1px #d81f0f;

--- a/core/src/TextareaFieldType/TextareaFieldType.js
+++ b/core/src/TextareaFieldType/TextareaFieldType.js
@@ -36,13 +36,15 @@ export class TextareaFieldType extends Component {
         <FieldLabel
           label={label}
           required={required}
+          fieldType="textarea"
           maxLength={maxLength || 150}
           valueLength={(value && value.length) || "0"}
         />
 
         <Textarea {...this.props} type="textarea" onChange={this.onChange} />
-
-        <FieldDescription description={this.props.description} />
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/TextareaFieldType/TextareaFieldType.js
+++ b/core/src/TextareaFieldType/TextareaFieldType.js
@@ -39,6 +39,7 @@ export class TextareaFieldType extends Component {
           fieldType="textarea"
           maxLength={maxLength || 150}
           valueLength={(value && value.length) || "0"}
+          tooltip={this.props.tooltip}
         />
 
         <Textarea {...this.props} type="textarea" onChange={this.onChange} />

--- a/core/src/TextareaFieldType/TextareaFieldType.js
+++ b/core/src/TextareaFieldType/TextareaFieldType.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import cx from "classnames";
 
 import { Textarea } from "../Textarea";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 /**
  * Controlled component
@@ -31,19 +33,16 @@ export class TextareaFieldType extends Component {
           (value && value.length) > (maxLength || 150) ? styles.Error : ""
         )}
       >
-        <p className={styles.TextareaFieldTypeLabel}>
-          <span>
-            {label}
-            {required && <span style={{ color: "#9a2803" }}>*</span>}
-          </span>
-          <span>
-            {(value && value.length) || "0"}/{maxLength || 150}
-          </span>
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
+        <FieldLabel
+          label={label}
+          required={required}
+          maxLength={maxLength || 150}
+          valueLength={(value && value.length) || "0"}
+        />
 
         <Textarea {...this.props} type="textarea" onChange={this.onChange} />
+
+        <FieldDescription description={this.props.description} />
       </label>
     );
   }

--- a/core/src/TextareaFieldType/TextareaFieldType.js
+++ b/core/src/TextareaFieldType/TextareaFieldType.js
@@ -36,7 +36,7 @@ export class TextareaFieldType extends Component {
         <FieldLabel
           label={label}
           required={required}
-          fieldType="textarea"
+          tag={this.props.tag}
           maxLength={maxLength || 150}
           valueLength={(value && value.length) || "0"}
           tooltip={this.props.tooltip}

--- a/core/src/TextareaFieldType/TextareaFieldType.less
+++ b/core/src/TextareaFieldType/TextareaFieldType.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     align-items: end;
-    font-size: @fieldLabelSize;
+    font-size: @field-label-size;
     line-height: 24px;
     color: #1a202c;
   }

--- a/core/src/TextareaFieldType/TextareaFieldType.less
+++ b/core/src/TextareaFieldType/TextareaFieldType.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     align-items: end;
-    font-size: @FieldLabelSize;
+    font-size: @fieldLabelSize;
     line-height: 24px;
     color: #1a202c;
   }

--- a/core/src/TextareaFieldType/TextareaFieldType.less
+++ b/core/src/TextareaFieldType/TextareaFieldType.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     align-items: end;
-    font-size: @labelTextSize;
+    font-size: @FieldLabelSize;
     line-height: 24px;
     color: #1a202c;
   }

--- a/core/src/TextareaFieldType/TextareaFieldType.less
+++ b/core/src/TextareaFieldType/TextareaFieldType.less
@@ -12,7 +12,7 @@
     align-items: end;
     font-size: @field-label-size;
     line-height: 24px;
-    color: #1a202c;
+    color: @zesty-dark-blue;
   }
   textarea {
     display: block;
@@ -23,6 +23,6 @@
 
 .TextareaFieldType.Error {
   input {
-    border: solid 1px #9a2803;
+    border: solid 1px @zesty-red;
   }
 }

--- a/core/src/UUIDFieldType/UUIDFieldType.js
+++ b/core/src/UUIDFieldType/UUIDFieldType.js
@@ -22,6 +22,7 @@ export class UUIDFieldType extends PureComponent {
           label={this.props.label}
           required={this.props.required}
           fieldType="uuid"
+          tooltip={this.props.tooltip}
         />
         <div className={styles.DateFieldTypeInput}>
           <i

--- a/core/src/UUIDFieldType/UUIDFieldType.js
+++ b/core/src/UUIDFieldType/UUIDFieldType.js
@@ -3,6 +3,8 @@ import cx from "classnames";
 import uuidv4 from "uuid/v4";
 
 import { Input } from "../Input";
+import { FieldDescription } from "../FieldDescription";
+import { FieldLabel } from "../FieldLabel";
 
 import styles from "./UUIDFieldType.less";
 export class UUIDFieldType extends PureComponent {
@@ -16,15 +18,11 @@ export class UUIDFieldType extends PureComponent {
   render() {
     return (
       <label className={cx(styles.UUIDFieldType, this.props.className)}>
-        <p className={styles.UUIDFieldTypeLabel}>
-          <span>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </span>
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
-
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="uuid"
+        />
         <div className={styles.DateFieldTypeInput}>
           <i
             className={cx(styles.Icon, "fa fa-clipboard")}
@@ -54,6 +52,9 @@ export class UUIDFieldType extends PureComponent {
             defaultValue={this.props.value || ""}
           />
         </div>
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </label>
     );
   }

--- a/core/src/UUIDFieldType/UUIDFieldType.js
+++ b/core/src/UUIDFieldType/UUIDFieldType.js
@@ -27,6 +27,7 @@ export class UUIDFieldType extends PureComponent {
           <i
             className={cx(styles.Icon, "fa fa-clipboard")}
             aria-hidden="true"
+            title="Click to Copy"
             onClick={e => {
               const input = document.createElement("input");
               document.body.appendChild(input);

--- a/core/src/UUIDFieldType/UUIDFieldType.js
+++ b/core/src/UUIDFieldType/UUIDFieldType.js
@@ -21,7 +21,7 @@ export class UUIDFieldType extends PureComponent {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="uuid"
+          tag={this.props.tag}
           tooltip={this.props.tooltip}
         />
         <div className={styles.DateFieldTypeInput}>

--- a/core/src/UUIDFieldType/UUIDFieldType.less
+++ b/core/src/UUIDFieldType/UUIDFieldType.less
@@ -1,11 +1,6 @@
 .UUIDFieldType {
   display: flex;
   flex-direction: column;
-  .UUIDFieldTypeLabel {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 3px;
-  }
 
   .DateFieldTypeInput {
     display: flex;

--- a/core/src/UrlFieldType/UrlFieldType.js
+++ b/core/src/UrlFieldType/UrlFieldType.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from "react";
 import cx from "classnames";
 
 import { Input } from "../Input";
+import { FieldLabel } from "../FieldLabel";
+import { FieldDescription } from "../FieldDescription";
 
 import styles from "./UrlFieldType.less";
 export class UrlFieldType extends PureComponent {
@@ -26,26 +28,22 @@ export class UrlFieldType extends PureComponent {
             : null
         )}
       >
-        <p className={styles.UrlFieldTypeLabel}>
-          <label>
-            {this.props.label}
-            {this.props.required && <span style={{ color: "#9a2803" }}>*</span>}
-          </label>
-          {this.props.maxLength && (
-            <span>
-              {this.props.value.length}/{this.props.maxLength}
-            </span>
-          )}
-        </p>
-
-        <p className={styles.Description}>{this.props.description}</p>
-
+        <FieldLabel
+          label={this.props.label}
+          required={this.props.required}
+          fieldType="url"
+          maxLength={this.props.maxLength}
+          valueLength={(this.props.value && this.props.value.length) || "0"}
+        />
         <Input
           type="url"
           required={this.props.required}
           onChange={this.onChange}
           value={this.props.value}
         />
+        {this.props.description && (
+          <FieldDescription description={this.props.description} />
+        )}
       </article>
     );
   }

--- a/core/src/UrlFieldType/UrlFieldType.js
+++ b/core/src/UrlFieldType/UrlFieldType.js
@@ -34,6 +34,7 @@ export class UrlFieldType extends PureComponent {
           fieldType="url"
           maxLength={this.props.maxLength}
           valueLength={(this.props.value && this.props.value.length) || "0"}
+          tooltip={this.props.tooltip}
         />
         <Input
           type="url"

--- a/core/src/UrlFieldType/UrlFieldType.js
+++ b/core/src/UrlFieldType/UrlFieldType.js
@@ -31,7 +31,7 @@ export class UrlFieldType extends PureComponent {
         <FieldLabel
           label={this.props.label}
           required={this.props.required}
-          fieldType="url"
+          tag={this.props.tag}
           maxLength={this.props.maxLength}
           valueLength={(this.props.value && this.props.value.length) || "0"}
           tooltip={this.props.tooltip}

--- a/core/src/typography.less
+++ b/core/src/typography.less
@@ -9,6 +9,7 @@
 @caption-font-size: 12px;
 @button-font-size: 14px;
 @body-font-size: 14px;
+@button-font-size: 12px;
 @input-font-size: 14px;
 @sub-headline-font-size: 20px;
 @title-font-size: 24px;
@@ -23,7 +24,8 @@
 // weights
 @font-light-weight: 300;
 @font-normal-weight: 500;
-@button-weight: 600;
+@font-bold-weight: 500;
+@button-weight: @font-bold-weight;
 
 // legacy variables (was camelcase)
 @labelTextSize: @field-label-size;

--- a/core/src/typography.less
+++ b/core/src/typography.less
@@ -14,7 +14,7 @@
 @titleFontSize: 24px;
 @headlineFontSize: 28px;
 @displayFontSize: 32px;
-@FieldLabelSize: 14px;
+@fieldLabelSize: 14px;
 @helperTextFontSize: 9px;
 
 // lineheights

--- a/core/src/typography.less
+++ b/core/src/typography.less
@@ -16,7 +16,7 @@
 @headline-font-size: 28px;
 @display-font-size: 32px;
 @field-label-size: 14px;
-@helper-text-font-size: 9px;
+@helper-text-font-size: 10px;
 
 // lineheights
 @label-line-height: 20px;

--- a/core/src/typography.less
+++ b/core/src/typography.less
@@ -1,16 +1,24 @@
 @import "colors.less";
 
-@labelTextSize: 16px;
-@defaultFont: Montserrat;
+// fonts
+@defaultFont: Montserrat, Arial, Sans-Serif;
+@secondaryFont: Verdana, Arial, Monaco, Sans-Serif;
+@inputFont: Arial, Sans-Serif;
 
 // font sizes
 @captionFontSize: 12px;
 @buttonFontSize: 14px;
-@bodyFontSize: 16px;
+@bodyFontSize: 14px;
+@inputFontSize: 14px;
 @subheadlineFontSize: 20px;
 @titleFontSize: 24px;
 @headlineFontSize: 28px;
 @displayFontSize: 32px;
+@FieldLabelSize: 14px;
+@helperTextFontSize: 9px;
+
+// lineheights
+@labelLineHeight: 20px;
 
 // weights
 @fontLightWeight: 300;

--- a/core/src/typography.less
+++ b/core/src/typography.less
@@ -1,34 +1,50 @@
 @import "colors.less";
 
 // fonts
-@defaultFont: Montserrat, Arial, Sans-Serif;
-@secondaryFont: Verdana, Arial, Monaco, Sans-Serif;
-@inputFont: Arial, Sans-Serif;
+@default-font: "Montserrat", Arial, Sans-Serif;
+@secondary-font: Verdana, Arial, Monaco, Sans-Serif;
+@input-font: Arial, Sans-Serif;
 
 // font sizes
-@captionFontSize: 12px;
-@buttonFontSize: 14px;
-@bodyFontSize: 14px;
-@inputFontSize: 14px;
-@subheadlineFontSize: 20px;
-@titleFontSize: 24px;
-@headlineFontSize: 28px;
-@displayFontSize: 32px;
-@fieldLabelSize: 14px;
-@helperTextFontSize: 9px;
+@caption-font-size: 12px;
+@button-font-size: 14px;
+@body-font-size: 14px;
+@input-font-size: 14px;
+@sub-headline-font-size: 20px;
+@title-font-size: 24px;
+@headline-font-size: 28px;
+@display-font-size: 32px;
+@field-label-size: 14px;
+@helper-text-font-size: 9px;
 
 // lineheights
-@labelLineHeight: 20px;
+@label-line-height: 20px;
 
 // weights
-@fontLightWeight: 300;
-@fontNormalWeight: 500;
-@buttonWeight: 600;
+@font-light-weight: 300;
+@font-normal-weight: 500;
+@button-weight: 600;
+
+// legacy variables (was camelcase)
+@labelTextSize: @field-label-size;
+@defaultFont: @default-font;
+@displayFontSize: @display-font-size;
+@helperTextFontSize: @helper-text-font-size;
+@captionFontSize: @caption-font-size;
+@buttonFontSize: @button-font-size;
+@bodyFontSize: @body-font-size;
+@inputFontSize: @input-font-size;
+@subheadline-font-size: @sub-headline-font-size;
+@titleFontSize: @title-font-size;
+@headlineFontSize: @headline-font-size;
+@fontLightWeight: @font-light-weight;
+@fontNormalWeight: @font-normal-weight;
+@buttonWeight: @button-weight;
 
 .display {
-  font-family: @defaultFont;
-  font-size: @displayFontSize;
-  font-weight: @fontLightWeight;
+  font-family: @default-font;
+  font-size: @display-font-size;
+  font-weight: @font-light-weight;
   line-height: 48px;
   letter-spacing: 0.32;
   &.reversed {
@@ -37,9 +53,9 @@
 }
 
 .headline {
-  font-family: @defaultFont;
+  font-family: @default-font;
   font-size: 28px;
-  font-weight: @fontLightWeight;
+  font-weight: @font-light-weight;
   line-height: 42px;
   letter-spacing: 0.32;
   &.reversed {
@@ -48,8 +64,8 @@
 }
 
 .title {
-  font-family: @defaultFont;
-  font-size: @titleFontSize;
+  font-family: @default-font;
+  font-size: @title-font-size;
   font-weight: normal;
   line-height: 36px;
   letter-spacing: 0.16;
@@ -59,17 +75,17 @@
 }
 
 .subheadline {
-  font-family: @defaultFont;
-  font-size: @subheadlineFontSize;
-  font-weight: @fontNormalWeight;
+  font-family: @default-font;
+  font-size: @sub-headline-font-size;
+  font-weight: @font-normal-weight;
   line-height: 28px;
   letter-spacing: 0.08;
 }
 
 .bodyText {
-  font-family: @defaultFont;
-  font-size: @bodyFontSize;
-  font-weight: @fontNormalWeight;
+  font-family: @default-font;
+  font-size: @body-font-size;
+  font-weight: @font-normal-weight;
   line-height: 24px;
   letter-spacing: 0;
   &.reversed {
@@ -78,17 +94,17 @@
 }
 
 .buttonText {
-  font-family: @defaultFont;
-  font-size: @buttonFontSize;
-  font-weight: @buttonWeight;
+  font-family: @default-font;
+  font-size: @button-font-size;
+  font-weight: @button-weight;
   line-height: 20px;
   letter-spacing: 0.12;
 }
 
 .caption {
-  font-family: @defaultFont;
-  font-size: @captionFontSize;
-  font-weight: @fontNormalWeight;
+  font-family: @default-font;
+  font-size: @caption-font-size;
+  font-weight: @font-normal-weight;
   line-height: 16px;
   letter-spacing: 0;
 }


### PR DESCRIPTION
Field Tyep components now have the option to pass
`tag="tagname"`
`tooltip="dont be a tooltip"`

Description field styles and tucked under input.

Some input font sizes changed to be smaller and reference typography.less and colors adjusted to use colors.less

![image](https://user-images.githubusercontent.com/729972/61337098-c6bc6f00-a7e8-11e9-8396-3ecf58fd9dd6.png)

![image](https://user-images.githubusercontent.com/729972/61337082-b906e980-a7e8-11e9-85bd-f6433479d1ae.png)

# Old

![image](https://user-images.githubusercontent.com/729972/61337203-329ed780-a7e9-11e9-87bc-76082a09762c.png)
