### PR TITLE
fixed depth2 sidebar styles

### DIFF
--- a/core/src/Nav/Node/Node.less
+++ b/core/src/Nav/Node/Node.less
@@ -8,7 +8,6 @@
   &:hover {
     background-color: lighten(@nav-border-color, 6%);
 
-
     .hide {
       visibility: visible;
     }
@@ -48,8 +47,7 @@
 }
 
 .actions {
-padding: 12px;
-
+  padding: 12px;
 }
 .action {
   color: @zesty-gray;
@@ -97,4 +95,9 @@ padding: 12px;
       }
     }
   }
+}
+
+.selected.depth2 {
+  background-color: darken(@zesty-light-blue, 12%);
+  outline: 1px solid @zesty-tab-blue;
 }


### PR DESCRIPTION
@shrunyan darken the second level depth2 and add a small outline to help differentiate to the eyes what is selected

![Screen Shot 2020-09-17 at 5 20 57 PM](https://user-images.githubusercontent.com/22800749/93541763-2ee67380-f90c-11ea-8758-213d531df072.png)
