### PR TITLE
setting a background-color on toggle button so the colors match acros…

### DIFF
--- a/core/src/ToggleButton/ToggleButton.less
+++ b/core/src/ToggleButton/ToggleButton.less
@@ -4,6 +4,7 @@
   padding: 3px;
   border-radius: 4px;
   border: 1px #ccc solid;
+  background-color: #EFEFEF;
 
   .default {
     padding: 6px 12px;


### PR DESCRIPTION
Safari default user agent stylesheet was giving a darker grey on the toggle buttons making the font color difficult to read. I set a background-color resulting in a consistent color across chromium and safari browsers 

Notes* https://stackoverflow.com/questions/6237455/chrome-renders-colours-differently-from-safari-and-firefox#:~:text=By%20default%20both%20Firefox%20and,different%20color%20profile%20as%20default.&text=Change%20Force%20color%20profile%20to,testify%20the%20rendered%20colors%20now.

original ticket on manager-ui with screen shots https://github.com/zesty-io/manager-ui/issues/239 