### PR TITLE
Feature/global z index

### DIFF
--- a/core/src/Infotip/Infotip.less
+++ b/core/src/Infotip/Infotip.less
@@ -5,7 +5,6 @@
   cursor: help;
   position: relative;
   font-size: 14px;
-  z-index: 100; // place above app stack
 
   .tipIcon {
     color: @zesty-tab-blue;
@@ -41,7 +40,7 @@
       color: @white;
       font-family: @font-family-secondary;
       padding: 15px 23px;
-      width: 25rem;
+      width: 250px;
       line-height: 20px;
       bottom: 26px;
       border-radius: 4px;


### PR DESCRIPTION
Removed z -index of a 100 that was causing overlapping in a variety of pages

Swapped out tooltip rem to px, fixed content from overflowing off viewport

<img width="347" alt="Screen Shot 2020-10-19 at 11 44 40 AM" src="https://user-images.githubusercontent.com/22800749/96515312-f7742b00-1219-11eb-99bf-4ff78efbdbc1.png">

<img width="356" alt="Screen Shot 2020-10-19 at 2 45 08 PM" src="https://user-images.githubusercontent.com/22800749/96515307-f5aa6780-1219-11eb-8fbb-e3900c5161b4.png">

