### PR TITLE
tightening up nav node spacing in content view

### DIFF
--- a/core/src/Nav/Node/Node.less
+++ b/core/src/Nav/Node/Node.less
@@ -22,11 +22,13 @@
     color: @zesty-light-blue;
     flex: 1;
     padding: 8px 16px;
+    display: flex;
     i,
     svg {
       padding: 0;
       margin-right: 8px;
       opacity: 0.6;
+      align-self: center;
     }
   }
 }

--- a/core/src/Nav/Node/Node.less
+++ b/core/src/Nav/Node/Node.less
@@ -48,7 +48,7 @@
 }
 
 .actions {
-  padding: 12px;
+  padding: 8px;
 }
 .action {
   color: @zesty-gray;

--- a/core/src/Nav/Parent/Parent.less
+++ b/core/src/Nav/Parent/Parent.less
@@ -32,6 +32,7 @@
   }
 
   ul {
+    line-height: 1.33;
     letter-spacing: 1px;
     list-style: none;
     margin-left: 8px;


### PR DESCRIPTION
tighten up the node height to be more consistent for code and schema view 
Original ticket: https://github.com/zesty-io/manager-ui/issues/278