### PR TITLE
resolved buttons inside labels are now clickable for fieldtypecolor.js

### DIFF
--- a/core/src/FieldTypeColor/FieldTypeColor.js
+++ b/core/src/FieldTypeColor/FieldTypeColor.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -14,7 +14,7 @@ export const FieldTypeColor = React.memo(function FieldTypeColor(props) {
   // console.log("Render:FieldTypeColor");
 
   const [color, setColor] = useState(props.value || "#ffffff");
-
+  const ref = useRef();
   return (
     <label className={cx(styles.FieldTypeColor, props.className)}>
       <FieldLabel
@@ -26,18 +26,24 @@ export const FieldTypeColor = React.memo(function FieldTypeColor(props) {
 
       <div className={styles.FieldTypeColorInput}>
         <Input
+          ref={ref}
           className={styles.ColorInput}
           type="color"
           required={props.required}
           value={color}
-          onChange={evt => {
+          onChange={(evt) => {
             if (props.onChange) {
               props.onChange(evt.target.value, props.name, props.datatype);
             }
             setColor(evt.target.value);
           }}
         />
-        <Button className={styles.Icon}>
+        <Button
+          onClick={() => {
+            ref.current.click();
+          }}
+          className={styles.Icon}
+        >
           <FontAwesomeIcon icon={faPaintBrush} />
         </Button>
       </div>


### PR DESCRIPTION
@shrunyan, @nibblebot helped me with using the React helper useRef that allows the button to be attached to the label. We chose this fix since it keeps the on hover styles. 

The long run we should stay away from putting buttons inside labels
 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#Accessibility_concerns

<img width="511" alt="Screen Shot 2020-10-21 at 4 03 00 PM" src="https://user-images.githubusercontent.com/22800749/96798968-e6145580-13b6-11eb-8c27-064d8aa25764.png">
