### PR TITLE
swapped description font color from zesty light gray to zesty-gray

### DIFF
--- a/core/src/FieldDescription/FieldDescription.less
+++ b/core/src/FieldDescription/FieldDescription.less
@@ -4,7 +4,7 @@
 .Description {
   font-size: @font-size-helper-text;
   font-family: @font-family-secondary;
-  color: @zesty-light-gray;
+  color: @zesty-gray;
   padding-top: 5px;
   margin-left: 3px;
   text-align: left;


### PR DESCRIPTION
swapped description font color from zesty-light-gray to zesty-gray

BEFORE
<img width="366" alt="Screen Shot 2020-10-22 at 2 04 24 PM" src="https://user-images.githubusercontent.com/22800749/96930540-ba55a600-1470-11eb-8462-a5d6d79cd7e7.png">

AFTER
<img width="344" alt="Screen Shot 2020-10-22 at 2 04 33 PM" src="https://user-images.githubusercontent.com/22800749/96930543-baee3c80-1470-11eb-8eac-5afbf91d96f6.png">
