### PR TITLE
fixed long width for all modals

### DIFF
--- a/core/src/Modal/Modal.less
+++ b/core/src/Modal/Modal.less
@@ -13,9 +13,7 @@
   display: none;
 
   &.Open {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    display: block;
   }
 
   &.Local {
@@ -29,9 +27,14 @@
 .Modal {
   background-color: @zesty-white;
   border-radius: 4px;
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  max-width: 50%;
+  margin: 5% auto 0;
+  min-width: 462px;
   padding: 32px;
   position: relative;
+  width: fit-content;
 
   &.Local {
     position: absolute;

--- a/core/src/Modal/Modal.less
+++ b/core/src/Modal/Modal.less
@@ -27,8 +27,7 @@
 .Modal {
   background-color: @zesty-white;
   border-radius: 4px;
-  display: flex;
-  flex-direction: column;
+  display: table;
   max-width: 50%;
   margin: 5% auto 0;
   min-width: 462px;

--- a/core/src/Modal/Modal.less
+++ b/core/src/Modal/Modal.less
@@ -13,7 +13,9 @@
   display: none;
 
   &.Open {
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   &.Local {
@@ -27,10 +29,7 @@
 .Modal {
   background-color: @zesty-white;
   border-radius: 4px;
-  display: table;
-  max-width: 50%;
-  margin: 5% auto 0;
-  min-width: 462px;
+  display: inline-block;
   padding: 32px;
   position: relative;
 


### PR DESCRIPTION
Updating the modal display:flex to  display:table, this fixes the extra width space across all modals.

Display table is supported across all main browsers 
https://caniuse.com/?search=table

<img width="599" alt="Screen Shot 2020-11-02 at 11 31 19 AM" src="https://user-images.githubusercontent.com/22800749/97911186-b8f16c80-1cff-11eb-88ca-cd516221129b.png">
<img width="595" alt="Screen Shot 2020-11-02 at 11 31 32 AM" src="https://user-images.githubusercontent.com/22800749/97911198-babb3000-1cff-11eb-8acf-a7e6f5a67a4b.png">
