### PR TITLE
fixed font-weight on links to match zeplin styleguide

### DIFF
--- a/core/src/AppLink/AppLink.less
+++ b/core/src/AppLink/AppLink.less
@@ -10,6 +10,7 @@
   text-shadow: 1px 1px 0 @white;
   transition-duration: 0.3s;
   transition-property: color, background-color;
+  font-weight: 600;
 
   &:hover,
   &:focus {

--- a/core/src/Url/Url.less
+++ b/core/src/Url/Url.less
@@ -10,6 +10,7 @@
   text-shadow: 1px 1px 0 @white;
   transition-duration: 0.3s;
   transition-property: color, background-color;
+  font-weight: 600;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Increased font weight on links to match zeplin styleguide 
https://app.zeplin.io/project/5bb69f5bdfef6551f65f76e8/screen/5bbe83590343415fc73607ff

Before 
<img width="159" alt="Screen Shot 2020-11-02 at 1 58 15 PM" src="https://user-images.githubusercontent.com/22800749/97924876-3673a780-1d15-11eb-8910-6229d5b0dc5e.png">

After
<img width="170" alt="Screen Shot 2020-11-02 at 1 57 41 PM" src="https://user-images.githubusercontent.com/22800749/97924886-3c698880-1d15-11eb-8230-76686cb80458.png">
