### PR TITLE
Feature/field validation helper color

### DIFF
--- a/core/src/FieldLabel/FieldLabel.less
+++ b/core/src/FieldLabel/FieldLabel.less
@@ -19,7 +19,7 @@
   .ValidationLimitHelper {
     font-size: @font-size-helper-text;
     font-family: @font-family-secondary;
-    color: @zesty-light-gray;
+    color: @zesty-gray;
   }
 
   .Tag {


### PR DESCRIPTION
Increase legibility for the validation helper code while matching the title label color

Issue ticket:  https://github.com/zesty-io/manager-ui/issues/335

<img width="165" alt="Screen Shot 2020-11-03 at 11 31 55 AM" src="https://user-images.githubusercontent.com/22800749/98032236-8f504800-1dc8-11eb-8dd6-336e159714d9.png">
