### PR TITLE
swapped baseline for center on notice svg

### DIFF
--- a/core/src/Notice/Notice.less
+++ b/core/src/Notice/Notice.less
@@ -3,7 +3,7 @@
 .Notice {
   padding: 8px;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   border: 1px solid @zesty-light-blue;
 
   .Icon {


### PR DESCRIPTION
fixes the slight offset for Notice svgs

Original Issue https://github.com/zesty-io/manager-ui/issues/336

<img width="137" alt="Screen Shot 2020-11-03 at 11 45 35 AM" src="https://user-images.githubusercontent.com/22800749/98033249-18b44a00-1dca-11eb-81a4-10a12dba303f.png">
