### PR TITLE
swapped overflow scroll to auto

### DIFF
--- a/core/src/Select/Select.less
+++ b/core/src/Select/Select.less
@@ -115,7 +115,7 @@
 
     .options {
       max-height: 600px;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
 
     .filter button {


### PR DESCRIPTION
The scroll bar is always turned on even if there is no content to scroll. By switching the scrollbar  overflow-y: scroll TO auto the scrollbar will only appear when the content is overflowing.

Reference Notes 

https://stackoverflow.com/questions/6689412/difference-between-html-overflow-auto-and-overflow-scroll#:~:text=Auto%20will%20only%20show%20a,and%20you%20cant%20scroll%20it.&text=overflow%3A%20scroll%20will%20hide%20all,on%20the%20element%20in%20question.


Current: 
<img width="816" alt="Screen Shot 2020-11-03 at 3 01 02 PM" src="https://user-images.githubusercontent.com/22800749/98050475-a1d97a00-1de6-11eb-9bc7-c0bf9c335e49.png">


`overflow-y: auto` turned on
<img width="857" alt="Screen Shot 2020-11-03 at 3 08 15 PM" src="https://user-images.githubusercontent.com/22800749/98050392-735b9f00-1de6-11eb-864c-b0f3a49e6110.png">


