### PR TITLE
swapped overflow's auto and set svg pixel size to be consistent

### DIFF
--- a/core/src/Select/Select.less
+++ b/core/src/Select/Select.less
@@ -115,7 +115,7 @@
 
     .options {
       max-height: 600px;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
 
     .filter button {
@@ -168,5 +168,8 @@
     // li a .name {
     //   flex: 1;
     // }
+  }
+  svg {
+    font-size: 16px;
   }
 }


### PR DESCRIPTION
1) overflow auto will populate only when needed 


Overflow : SCroll
<img width="402" alt="Screen Shot 2020-11-06 at 2 02 41 PM" src="https://user-images.githubusercontent.com/22800749/98418927-d2b0ed80-2038-11eb-9643-51cf2e552365.png">

Overflow : Auto(scroll bar will populate if content needs )
<img width="410" alt="Screen Shot 2020-11-06 at 2 02 46 PM" src="https://user-images.githubusercontent.com/22800749/98418957-e3f9fa00-2038-11eb-8211-343c94b0d136.png">

2) svgs ins selectors are now set to zeplin's styleguide 16px and are consistent across browsers
Original ticket : https://github.com/zesty-io/manager-ui/issues/346

<img width="461" alt="Screen Shot 2020-11-06 at 1 59 01 PM" src="https://user-images.githubusercontent.com/22800749/98418654-3c7cc780-2038-11eb-94fd-bb9c7807ea2f.png">
