### PR TITLE
refactor: nav node actions now require providing a react component

### DIFF
--- a/core/src/Nav/Node/Node.js
+++ b/core/src/Nav/Node/Node.js
@@ -36,9 +36,13 @@ export function Node(props) {
                 ? action.props.available(props)
                 : true;
 
+              // Filter out props which will not translate to the DOM
+              const { showIcon, available, ...filteredProps } = action.props;
+              const child = { ...action, props: filteredProps };
+
               return (
                 isAvailable &&
-                React.cloneElement(action, {
+                React.cloneElement(child, {
                   key: index,
                   className: cx(
                     styles.action,
@@ -46,10 +50,6 @@ export function Node(props) {
                     action.props.className
                   ),
                   onClick: () => action.props.onClick(props),
-
-                  // Remove props which will not translate to the DOM
-                  showIcon: null,
-                  available: null,
                 })
               );
             })}

--- a/core/src/Nav/Node/Node.js
+++ b/core/src/Nav/Node/Node.js
@@ -3,11 +3,7 @@ import { Link } from "react-router-dom";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faEyeSlash,
-  faCaretLeft,
-  faCaretDown,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCaretLeft, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
 import styles from "./Node.less";
 export function Node(props) {
@@ -33,27 +29,30 @@ export function Node(props) {
 
           {/* Only linkable nodes can have actions */}
           <span className={styles.actions}>
-            {props.actions &&
-              props.actions.map((action, i) => {
-                return (
-                  // Run consumer provided function to determine
-                  // whether action is available
-                  (action.available ? action.available(props) : true) && (
-                    <i
-                      key={i}
-                      className={cx(
-                        styles.action,
-                        // Determines whether the action icon is persistently shown
-                        // or shown on hover
-                        action.showIcon ? null : styles.hide,
-                        action.icon,
-                        action.styles
-                      )}
-                      onClick={() => action.onClick(props)}
-                    />
-                  )
-                );
-              })}
+            {React.Children.map(props.actions, (action, index) => {
+              // Run consumer provided function to determine
+              // whether action is available
+              const isAvailable = action.props.available
+                ? action.props.available(props)
+                : true;
+
+              return (
+                isAvailable &&
+                React.cloneElement(action, {
+                  key: index,
+                  className: cx(
+                    styles.action,
+                    action.props.showIcon ? null : styles.hide,
+                    action.props.className
+                  ),
+                  onClick: () => action.props.onClick(props),
+
+                  // Remove props which will not translate to the DOM
+                  showIcon: null,
+                  available: null,
+                })
+              );
+            })}
           </span>
         </>
       )}

--- a/core/src/Nav/Node/Node.less
+++ b/core/src/Nav/Node/Node.less
@@ -53,6 +53,7 @@
   padding: 8px;
 }
 .action {
+  cursor: pointer;
   color: @zesty-gray;
 
   &:hover,

--- a/core/src/Nav/Node/Node.less
+++ b/core/src/Nav/Node/Node.less
@@ -54,7 +54,6 @@
 }
 .action {
   cursor: pointer;
-  color: @zesty-gray;
 
   &:hover,
   &:active,


### PR DESCRIPTION
**Significant change**. Switching from an array of objects describing the actions to an array of React Components which are the actions. 

- affects the Content and Code navs within the manager-ui; https://github.com/zesty-io/manager-ui/pull/534/files