### PR TITLE
fix: replace riot with media modal prosemirror inline/wysiwyg

### DIFF
--- a/core/src/FieldTypeEditor/Editors/Basic.js
+++ b/core/src/FieldTypeEditor/Editors/Basic.js
@@ -26,7 +26,7 @@ export class BasicEditor extends React.Component {
     this.state = {
       showLinkModal: false,
       showEmbedModal: false,
-      showEmbedModalOptions: {}
+      showEmbedModalOptions: {},
     };
   }
   componentDidMount() {
@@ -48,12 +48,12 @@ export class BasicEditor extends React.Component {
     ) {
       this.setState({
         [name]: true,
-        [`${name}Options`]: options
+        [`${name}Options`]: options,
       });
     }
   };
 
-  onModalClose = name => this.setState({ [name]: false });
+  onModalClose = (name) => this.setState({ [name]: false });
 
   render() {
     return (
@@ -71,7 +71,10 @@ export class BasicEditor extends React.Component {
                 open={this.state.showEmbedModal}
               />
 
-              <MenuBar menu={menu} view={view} />
+              <MenuBar
+                menu={menu({ mediaBrowser: this.props.mediaBrowser })}
+                view={view}
+              />
               <div ref={this.ref}>{editor}</div>
             </div>
           )}
@@ -84,7 +87,7 @@ export class BasicEditor extends React.Component {
             },
             video(node, view, getPos) {
               return new VideoResizeView(node, view, getPos);
-            }
+            },
           }}
         />
       </div>

--- a/core/src/FieldTypeEditor/Editors/Inline.js
+++ b/core/src/FieldTypeEditor/Editors/Inline.js
@@ -14,7 +14,7 @@ import { IframeResizeView } from "./prosemirror-views/IframeResizeView";
 import { VideoResizeView } from "./prosemirror-views/VideoResizeView";
 
 import styles from "./Inline.less";
-export function InlineEditor({ value, onChange }) {
+export function InlineEditor({ value, onChange, mediaBrowser }) {
   return (
     <HtmlEditor
       options={{ plugins, schema }}
@@ -23,7 +23,7 @@ export function InlineEditor({ value, onChange }) {
       render={({ editor, view }) => (
         <section className={styles.InlineEditor}>
           <Floater view={view}>
-            <MenuBar menu={inline} view={view} />
+            <MenuBar menu={inline({ mediaBrowser })} view={view} />
           </Floater>
           {editor}
         </section>
@@ -37,7 +37,7 @@ export function InlineEditor({ value, onChange }) {
         },
         video(node, view, getPos) {
           return new VideoResizeView(node, view, getPos);
-        }
+        },
       }}
     />
   );

--- a/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/index.js
+++ b/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/index.js
@@ -1,2 +1,2 @@
 export { menu } from "./menu";
-export { default as inline } from "./inline-menu";
+export { inline } from "./inline-menu";

--- a/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/inline-menu.js
+++ b/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/inline-menu.js
@@ -3,7 +3,7 @@ import {
   // lift,
   setBlockType,
   toggleMark,
-  wrapIn
+  wrapIn,
 } from "prosemirror-commands";
 // import { redo, undo } from "prosemirror-history";
 import { wrapInList } from "prosemirror-schema-list";
@@ -12,7 +12,7 @@ import { wrapInList } from "prosemirror-schema-list";
 import { schema } from "../react-prosemirror-schema";
 import icons from "./icons";
 
-const markActive = type => state => {
+const markActive = (type) => (state) => {
   const { from, $from, to, empty } = state.selection;
 
   return empty
@@ -20,7 +20,7 @@ const markActive = type => state => {
     : state.doc.rangeHasMark(from, to, type);
 };
 
-const blockActive = (type, attrs = {}) => state => {
+const blockActive = (type, attrs = {}) => (state) => {
   const { $from, to, node } = state.selection;
 
   if (node) {
@@ -30,7 +30,7 @@ const blockActive = (type, attrs = {}) => state => {
   return to <= $from.end() && $from.parent.hasMarkup(type, attrs);
 };
 
-const canInsert = type => state => {
+const canInsert = (type) => (state) => {
   const { $from } = state.selection;
 
   for (let d = $from.depth; d >= 0; d--) {
@@ -49,192 +49,194 @@ const promptForURL = () => {
   return url;
 };
 
-export default {
-  marks: {
-    em: {
-      title: "Italic",
-      content: icons.em,
-      active: markActive(schema.marks.em),
-      run: toggleMark(schema.marks.em)
-    },
-    strong: {
-      title: "Bold",
-      content: icons.strong,
-      active: markActive(schema.marks.strong),
-      run: toggleMark(schema.marks.strong)
-    },
-    underline: {
-      title: "Underline",
-      content: icons.underline,
-      active: markActive(schema.marks.underline),
-      run: toggleMark(schema.marks.underline)
-    },
-    link: {
-      title: "Add or remove link",
-      content: icons.link,
-      active: markActive(schema.marks.link),
-      enable: state => !state.selection.empty,
-      run(state, dispatch) {
-        if (markActive(schema.marks.link)(state)) {
-          toggleMark(schema.marks.link)(state, dispatch);
-          return true;
-        }
-
-        const href = promptForURL();
-        if (!href) return false;
-
-        toggleMark(schema.marks.link, { href })(state, dispatch);
-        // view.focus()
-      }
-    }
-
-    // subscript: {
-    //   title: "Toggle subscript",
-    //   content: icons.subscript,
-    //   active: markActive(schema.marks.subscript),
-    //   run: toggleMark(schema.marks.subscript)
-    // },
-    // superscript: {
-    //   title: "Toggle superscript",
-    //   content: icons.superscript,
-    //   active: markActive(schema.marks.superscript),
-    //   run: toggleMark(schema.marks.superscript)
-    // },
-    //
-    // strikethrough: {
-    //   title: "Toggle strikethrough",
-    //   content: icons.strikethrough,
-    //   active: markActive(schema.marks.strikethrough),
-    //   run: toggleMark(schema.marks.strikethrough)
-    // }
-  },
-  blocks: {
-    // code_block: {
-    //   title: "Change to code block",
-    //   content: icons.code_block,
-    //   active: blockActive(schema.nodes.code_block),
-    //   enable: setBlockType(schema.nodes.code_block),
-    //   run: setBlockType(schema.nodes.code_block)
-    // },
-    h1: {
-      title: "Change to heading level 1",
-      content: "H1",
-      active: blockActive(schema.nodes.heading, { level: 1 }),
-      enable: setBlockType(schema.nodes.heading, { level: 1 }),
-      run: setBlockType(schema.nodes.heading, { level: 1 })
-    },
-    h2: {
-      title: "Change to heading level 2",
-      content: "H2",
-      active: blockActive(schema.nodes.heading, { level: 2 }),
-      enable: setBlockType(schema.nodes.heading, { level: 2 }),
-      run: setBlockType(schema.nodes.heading, { level: 2 })
-    },
-    h3: {
-      title: "Change to heading level 3",
-      content: "H3",
-      active: blockActive(schema.nodes.heading, { level: 3 }),
-      enable: setBlockType(schema.nodes.heading, { level: 3 }),
-      run: setBlockType(schema.nodes.heading, { level: 3 })
-    },
-    h4: {
-      title: "Change to heading level 4",
-      content: "H4",
-      active: blockActive(schema.nodes.heading, { level: 4 }),
-      enable: setBlockType(schema.nodes.heading, { level: 4 }),
-      run: setBlockType(schema.nodes.heading, { level: 4 })
-    },
-    h5: {
-      title: "Change to heading level 5",
-      content: "H5",
-      active: blockActive(schema.nodes.heading, { level: 5 }),
-      enable: setBlockType(schema.nodes.heading, { level: 5 }),
-      run: setBlockType(schema.nodes.heading, { level: 5 })
-    },
-    h6: {
-      title: "Change to heading level 6",
-      content: "H6",
-      active: blockActive(schema.nodes.heading, { level: 6 }),
-      enable: setBlockType(schema.nodes.heading, { level: 6 }),
-      run: setBlockType(schema.nodes.heading, { level: 6 })
-    },
-    plain: {
-      title: "Change to paragraph",
-      content: icons.paragraph,
-      active: blockActive(schema.nodes.paragraph),
-      enable: setBlockType(schema.nodes.paragraph),
-      run: setBlockType(schema.nodes.paragraph)
-    },
-    code_block: {
-      title: "Change to code block",
-      content: icons.code_block,
-      active: blockActive(schema.nodes.code_block),
-      enable: setBlockType(schema.nodes.code_block),
-      run: setBlockType(schema.nodes.code_block)
-    },
-    blockquote: {
-      title: "Wrap in block quote",
-      content: icons.blockquote,
-      active: blockActive(schema.nodes.blockquote),
-      enable: wrapIn(schema.nodes.blockquote),
-      run: wrapIn(schema.nodes.blockquote)
-    },
-    bullet_list: {
-      title: "Wrap in bullet list",
-      content: icons.bullet_list,
-      active: blockActive(schema.nodes.bullet_list),
-      enable: wrapInList(schema.nodes.bullet_list),
-      run: wrapInList(schema.nodes.bullet_list)
-    },
-    ordered_list: {
-      title: "Wrap in ordered list",
-      content: icons.ordered_list,
-      active: blockActive(schema.nodes.ordered_list),
-      enable: wrapInList(schema.nodes.ordered_list),
-      run: wrapInList(schema.nodes.ordered_list)
-    },
-    indent: {
-      title: "Indent",
-      content: icons.indent,
-      active: markActive(schema.marks.indent),
-      run: toggleMark(schema.marks.indent)
-    }
-  },
-  insert: {
-    image: {
-      title: "Insert image from media library",
-      content: icons.image,
-      enable: canInsert(schema.nodes.image),
-      run: (state, dispatch) => {
-        riot.mount(document.querySelector("#modalMount"), "media-app-modal", {
-          limit: 10,
-          callback: images => {
-            images.forEach(image => {
-              dispatch(
-                state.tr.replaceSelectionWith(
-                  schema.nodes.image.createAndFill({
-                    src: image.url
-                  })
-                )
-              );
-            });
+export function inline(options) {
+  return {
+    marks: {
+      em: {
+        title: "Italic",
+        content: icons.em,
+        active: markActive(schema.marks.em),
+        run: toggleMark(schema.marks.em),
+      },
+      strong: {
+        title: "Bold",
+        content: icons.strong,
+        active: markActive(schema.marks.strong),
+        run: toggleMark(schema.marks.strong),
+      },
+      underline: {
+        title: "Underline",
+        content: icons.underline,
+        active: markActive(schema.marks.underline),
+        run: toggleMark(schema.marks.underline),
+      },
+      link: {
+        title: "Add or remove link",
+        content: icons.link,
+        active: markActive(schema.marks.link),
+        enable: (state) => !state.selection.empty,
+        run(state, dispatch) {
+          if (markActive(schema.marks.link)(state)) {
+            toggleMark(schema.marks.link)(state, dispatch);
+            return true;
           }
-        });
-      }
-    }
-  }
-  // history: {
-  //   undo: {
-  //     title: "Undo last change",
-  //     content: icons.undo,
-  //     enable: undo,
-  //     run: undo
-  //   },
-  //   redo: {
-  //     title: "Redo last undone change",
-  //     content: icons.redo,
-  //     enable: redo,
-  //     run: redo
-  //   }
-  // }
-};
+
+          const href = promptForURL();
+          if (!href) return false;
+
+          toggleMark(schema.marks.link, { href })(state, dispatch);
+          // view.focus()
+        },
+      },
+
+      // subscript: {
+      //   title: "Toggle subscript",
+      //   content: icons.subscript,
+      //   active: markActive(schema.marks.subscript),
+      //   run: toggleMark(schema.marks.subscript)
+      // },
+      // superscript: {
+      //   title: "Toggle superscript",
+      //   content: icons.superscript,
+      //   active: markActive(schema.marks.superscript),
+      //   run: toggleMark(schema.marks.superscript)
+      // },
+      //
+      // strikethrough: {
+      //   title: "Toggle strikethrough",
+      //   content: icons.strikethrough,
+      //   active: markActive(schema.marks.strikethrough),
+      //   run: toggleMark(schema.marks.strikethrough)
+      // }
+    },
+    blocks: {
+      // code_block: {
+      //   title: "Change to code block",
+      //   content: icons.code_block,
+      //   active: blockActive(schema.nodes.code_block),
+      //   enable: setBlockType(schema.nodes.code_block),
+      //   run: setBlockType(schema.nodes.code_block)
+      // },
+      h1: {
+        title: "Change to heading level 1",
+        content: "H1",
+        active: blockActive(schema.nodes.heading, { level: 1 }),
+        enable: setBlockType(schema.nodes.heading, { level: 1 }),
+        run: setBlockType(schema.nodes.heading, { level: 1 }),
+      },
+      h2: {
+        title: "Change to heading level 2",
+        content: "H2",
+        active: blockActive(schema.nodes.heading, { level: 2 }),
+        enable: setBlockType(schema.nodes.heading, { level: 2 }),
+        run: setBlockType(schema.nodes.heading, { level: 2 }),
+      },
+      h3: {
+        title: "Change to heading level 3",
+        content: "H3",
+        active: blockActive(schema.nodes.heading, { level: 3 }),
+        enable: setBlockType(schema.nodes.heading, { level: 3 }),
+        run: setBlockType(schema.nodes.heading, { level: 3 }),
+      },
+      h4: {
+        title: "Change to heading level 4",
+        content: "H4",
+        active: blockActive(schema.nodes.heading, { level: 4 }),
+        enable: setBlockType(schema.nodes.heading, { level: 4 }),
+        run: setBlockType(schema.nodes.heading, { level: 4 }),
+      },
+      h5: {
+        title: "Change to heading level 5",
+        content: "H5",
+        active: blockActive(schema.nodes.heading, { level: 5 }),
+        enable: setBlockType(schema.nodes.heading, { level: 5 }),
+        run: setBlockType(schema.nodes.heading, { level: 5 }),
+      },
+      h6: {
+        title: "Change to heading level 6",
+        content: "H6",
+        active: blockActive(schema.nodes.heading, { level: 6 }),
+        enable: setBlockType(schema.nodes.heading, { level: 6 }),
+        run: setBlockType(schema.nodes.heading, { level: 6 }),
+      },
+      plain: {
+        title: "Change to paragraph",
+        content: icons.paragraph,
+        active: blockActive(schema.nodes.paragraph),
+        enable: setBlockType(schema.nodes.paragraph),
+        run: setBlockType(schema.nodes.paragraph),
+      },
+      code_block: {
+        title: "Change to code block",
+        content: icons.code_block,
+        active: blockActive(schema.nodes.code_block),
+        enable: setBlockType(schema.nodes.code_block),
+        run: setBlockType(schema.nodes.code_block),
+      },
+      blockquote: {
+        title: "Wrap in block quote",
+        content: icons.blockquote,
+        active: blockActive(schema.nodes.blockquote),
+        enable: wrapIn(schema.nodes.blockquote),
+        run: wrapIn(schema.nodes.blockquote),
+      },
+      bullet_list: {
+        title: "Wrap in bullet list",
+        content: icons.bullet_list,
+        active: blockActive(schema.nodes.bullet_list),
+        enable: wrapInList(schema.nodes.bullet_list),
+        run: wrapInList(schema.nodes.bullet_list),
+      },
+      ordered_list: {
+        title: "Wrap in ordered list",
+        content: icons.ordered_list,
+        active: blockActive(schema.nodes.ordered_list),
+        enable: wrapInList(schema.nodes.ordered_list),
+        run: wrapInList(schema.nodes.ordered_list),
+      },
+      indent: {
+        title: "Indent",
+        content: icons.indent,
+        active: markActive(schema.marks.indent),
+        run: toggleMark(schema.marks.indent),
+      },
+    },
+    insert: {
+      image: {
+        title: "Insert image from media library",
+        content: icons.image,
+        enable: canInsert(schema.nodes.image),
+        run: (state, dispatch) => {
+          options.mediaBrowser({
+            limit: 10,
+            callback: (images) => {
+              images.forEach((image) => {
+                dispatch(
+                  state.tr.replaceSelectionWith(
+                    schema.nodes.image.createAndFill({
+                      src: image.url,
+                    })
+                  )
+                );
+              });
+            },
+          });
+        },
+      },
+    },
+    // history: {
+    //   undo: {
+    //     title: "Undo last change",
+    //     content: icons.undo,
+    //     enable: undo,
+    //     run: undo
+    //   },
+    //   redo: {
+    //     title: "Redo last undone change",
+    //     content: icons.redo,
+    //     enable: redo,
+    //     run: redo
+    //   }
+    // }
+  };
+}

--- a/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/menu.js
+++ b/core/src/FieldTypeEditor/Editors/react-prosemirror-menu/menu.js
@@ -8,7 +8,7 @@ import { schema } from "../react-prosemirror-schema";
 import icons from "./icons";
 import characters from "./characters";
 
-export const markActive = type => state => {
+export const markActive = (type) => (state) => {
   const { from, $from, to, empty } = state.selection;
 
   return empty
@@ -16,7 +16,7 @@ export const markActive = type => state => {
     : state.doc.rangeHasMark(from, to, type);
 };
 
-const blockActive = (type, attrs = {}) => state => {
+const blockActive = (type, attrs = {}) => (state) => {
   const { $from, to, node } = state.selection;
 
   if (node) {
@@ -26,7 +26,7 @@ const blockActive = (type, attrs = {}) => state => {
   return to <= $from.end() && $from.parent.hasMarkup(type, attrs);
 };
 
-const canInsert = type => state => {
+const canInsert = (type) => (state) => {
   const { $from } = state.selection;
 
   for (let d = $from.depth; d >= 0; d--) {
@@ -40,307 +40,309 @@ const canInsert = type => state => {
   return false;
 };
 
-export const menu = {
-  marks: {
-    em: {
-      title: "Toggle emphasis",
-      content: icons.em,
-      active: markActive(schema.marks.em),
-      run: toggleMark(schema.marks.em)
-    },
-    strong: {
-      title: "Toggle strong",
-      content: icons.strong,
-      active: markActive(schema.marks.strong),
-      run: toggleMark(schema.marks.strong)
-    },
-    subscript: {
-      title: "Toggle subscript",
-      content: icons.subscript,
-      active: markActive(schema.marks.subscript),
-      run: toggleMark(schema.marks.subscript)
-    },
-    superscript: {
-      title: "Toggle superscript",
-      content: icons.superscript,
-      active: markActive(schema.marks.superscript),
-      run: toggleMark(schema.marks.superscript)
-    },
-    underline: {
-      title: "Toggle underline",
-      content: icons.underline,
-      active: markActive(schema.marks.underline),
-      run: toggleMark(schema.marks.underline)
-    },
-    strikethrough: {
-      title: "Toggle strikethrough",
-      content: icons.strikethrough,
-      active: markActive(schema.marks.strikethrough),
-      run: toggleMark(schema.marks.strikethrough)
-    },
-    link: {
-      title: "Add or remove link",
-      content: icons.link,
-      active: markActive(schema.marks.link),
-      enable: state => !state.selection.empty,
-      run(state, dispatch, view) {
-        // Remove existing links
-        if (markActive(schema.marks.link)(state)) {
-          toggleMark(schema.marks.link)(state, dispatch);
-        } else {
-          zesty.trigger("PROSEMIRROR_DIALOG_OPEN", "showLinkModal", { view });
-        }
-        return true;
-      }
-    }
-  },
-  alignment: {
-    left: {
-      title: "Left align text",
-      content: icons.align_left,
-      active: markActive(schema.marks.alignLeft),
-      run: toggleMark(schema.marks.alignLeft)
-    },
-    center: {
-      title: "Center align text",
-      content: icons.align_center,
-      active: markActive(schema.marks.alignCenter),
-      run: toggleMark(schema.marks.alignCenter)
-    },
-    justify: {
-      title: "Justify align text",
-      content: icons.align_justify,
-      active: markActive(schema.marks.alignJustify),
-      run: toggleMark(schema.marks.alignJustify)
-    },
-    right: {
-      title: "Right align text",
-      content: icons.align_right,
-      active: markActive(schema.marks.alignRight),
-      run: toggleMark(schema.marks.alignRight)
-    }
-  },
-
-  headings_dropdown: {
-    title: "Change Heading",
-    content: "Heading",
-    // classname: "dropdown-menu-list",
-    children: ["1", "2", "3", "4", "5", "6"].reduce((acc, level) => {
-      acc[level] = {
-        title: `Heading ${level}`,
-        content: `Level ${level}`,
-        active: blockActive(schema.nodes.heading, { level: level }),
-        enable: setBlockType(schema.nodes.heading, { level: level }),
-        run: setBlockType(schema.nodes.heading, { level: level })
-      };
-
-      return acc;
-    }, {})
-  },
-
-  embed_dropdown: {
-    title: "Embed Content",
-    content: "Embed",
-    classname: "dropdown-menu-list",
-    children: ["Instagram", "YouTube", "Twitframe"].reduce((acc, service) => {
-      acc[service] = {
-        title: `${service}`,
-        content: `${service}`,
-        enable: canInsert(schema.nodes.iframe),
-        run: (state, dispatch, view) => {
-          zesty.trigger("PROSEMIRROR_DIALOG_OPEN", "showEmbedModal", {
-            service,
-            view
-          });
-        }
-      };
-
-      return acc;
-    }, {})
-  },
-
-  blocks: {
-    plain: {
-      title: "Change to paragraph",
-      content: icons.paragraph,
-      active: blockActive(schema.nodes.paragraph),
-      enable: setBlockType(schema.nodes.paragraph),
-      run: setBlockType(schema.nodes.paragraph)
-    },
-    code_block: {
-      title: "Change to code block",
-      content: icons.code_block,
-      active: blockActive(schema.nodes.code_block),
-      enable: setBlockType(schema.nodes.code_block),
-      run: setBlockType(schema.nodes.code_block)
-    },
-    blockquote: {
-      title: "Change to block quote",
-      content: icons.blockquote,
-      active: blockActive(schema.nodes.blockquote),
-      enable: setBlockType(schema.nodes.blockquote),
-      run: setBlockType(schema.nodes.blockquote)
-    },
-    bullet_list: {
-      title: "Wrap in bullet list",
-      content: icons.bullet_list,
-      active: blockActive(schema.nodes.bullet_list),
-      enable: wrapInList(schema.nodes.bullet_list),
-      run: wrapInList(schema.nodes.bullet_list)
-    },
-    ordered_list: {
-      title: "Wrap in ordered list",
-      content: icons.ordered_list,
-      active: blockActive(schema.nodes.ordered_list),
-      enable: wrapInList(schema.nodes.ordered_list),
-      run: wrapInList(schema.nodes.ordered_list)
-    },
-    indent: {
-      title: "Indent",
-      content: icons.indent,
-      active: markActive(schema.marks.indent),
-      run: toggleMark(schema.marks.indent)
-    }
-    // outdent: {
-    //   title: "Dedent",
-    //   content: icons.outdent,
-    //   active: markActive(schema.marks.dedent),
-    //   run: toggleMark(schema.marks.dedent)
-    // }
-  },
-
-  insert: {
-    // footnote: {
-    //   title: "Insert footnote",
-    //   content: icons.footnote,
-    //   enable: canInsert(schema.nodes.footnote),
-    //   run: (state, dispatch) => {
-    //     const footnote = schema.nodes.footnote.create();
-    //     dispatch(state.tr.replaceSelectionWith(footnote));
-    //   }
-    // },
-    hr: {
-      title: "Insert horizontal rule",
-      content: "HR",
-      enable: canInsert(schema.nodes.hr),
-      run: (state, dispatch) => {
-        const hr = schema.nodes.hr.create();
-        dispatch(state.tr.replaceSelectionWith(hr));
-      }
-    },
-    table: {
-      title: "Insert table",
-      content: icons.table,
-      enable: canInsert(schema.nodes.table),
-      run: (state, dispatch) => {
-        // const { from } = state.selection
-        let rowCount = window && window.prompt("How many rows?", 2);
-        let colCount = window && window.prompt("How many columns?", 2);
-
-        const cells = [];
-        while (colCount--) {
-          cells.push(schema.nodes.table_cell.createAndFill());
-        }
-
-        const rows = [];
-        while (rowCount--) {
-          rows.push(schema.nodes.table_row.createAndFill(null, cells));
-        }
-
-        const body = schema.nodes.table_body.createAndFill(null, rows);
-        const table = schema.nodes.table.createAndFill(null, body);
-
-        dispatch(state.tr.replaceSelectionWith(table));
-
-        // const tr = state.tr.replaceSelectionWith(table)
-        // tr.setSelection(Selection.near(tr.doc.resolve(from)))
-        // dispatch(tr.scrollIntoView())
-        // view.focus()
-      }
-    }
-    // table: {
-    // addColumnBefore: {
-    //   title: 'Insert column before',
-    //   content: icons.after,
-    //   active: addColumnBefore, // TOOD: active -> select
-    //   run: addColumnBefore
-    // },
-    // addColumnAfter: {
-    //   title: 'Insert column before',
-    //   content: icons.before,
-    //   active: addColumnAfter, // TOOD: active -> select
-    //   run: addColumnAfter
-    // }
-    // }
-  },
-  special_character_dropdown: {
-    title: "Insert special character",
-    content: "Special Character",
-    classname: "dropdown-menu-row",
-    children: characters.reduce((acc, char) => {
-      acc[char] = {
-        title: `Insert Character: ${char}`,
-        content: char,
-        enable: canInsert(schema.nodes.text),
-        run: (state, dispatch) => {
-          dispatch(state.tr.replaceSelectionWith(schema.text(char)));
-        }
-      };
-
-      return acc;
-    }, {})
-  },
-  media: {
-    image: {
-      title: "Insert image from media library",
-      content: icons.image,
-      enable: canInsert(schema.nodes.image),
-      run: (state, dispatch) => {
-        riot.mount(document.querySelector("#modalMount"), "media-app-modal", {
-          limit: 10,
-          callback: images => {
-            const imageNodes = images.map(image =>
-              schema.nodes.image.createAndFill({
-                src: image.url,
-                title: image.title,
-                "data-zuid": image.id
-              })
-            );
-
-            dispatch(
-              state.tr.replaceSelection(
-                new Slice(Fragment.from(imageNodes), 0, 0)
-              )
-            );
+export function menu(options) {
+  return {
+    marks: {
+      em: {
+        title: "Toggle emphasis",
+        content: icons.em,
+        active: markActive(schema.marks.em),
+        run: toggleMark(schema.marks.em),
+      },
+      strong: {
+        title: "Toggle strong",
+        content: icons.strong,
+        active: markActive(schema.marks.strong),
+        run: toggleMark(schema.marks.strong),
+      },
+      subscript: {
+        title: "Toggle subscript",
+        content: icons.subscript,
+        active: markActive(schema.marks.subscript),
+        run: toggleMark(schema.marks.subscript),
+      },
+      superscript: {
+        title: "Toggle superscript",
+        content: icons.superscript,
+        active: markActive(schema.marks.superscript),
+        run: toggleMark(schema.marks.superscript),
+      },
+      underline: {
+        title: "Toggle underline",
+        content: icons.underline,
+        active: markActive(schema.marks.underline),
+        run: toggleMark(schema.marks.underline),
+      },
+      strikethrough: {
+        title: "Toggle strikethrough",
+        content: icons.strikethrough,
+        active: markActive(schema.marks.strikethrough),
+        run: toggleMark(schema.marks.strikethrough),
+      },
+      link: {
+        title: "Add or remove link",
+        content: icons.link,
+        active: markActive(schema.marks.link),
+        enable: (state) => !state.selection.empty,
+        run(state, dispatch, view) {
+          // Remove existing links
+          if (markActive(schema.marks.link)(state)) {
+            toggleMark(schema.marks.link)(state, dispatch);
+          } else {
+            zesty.trigger("PROSEMIRROR_DIALOG_OPEN", "showLinkModal", { view });
           }
-        });
-      }
+          return true;
+        },
+      },
     },
-    left: {
-      title: "Float left",
-      content: icons.float_left,
-      active: markActive(schema.marks.floatLeft),
-      run: toggleMark(schema.marks.floatLeft)
+    alignment: {
+      left: {
+        title: "Left align text",
+        content: icons.align_left,
+        active: markActive(schema.marks.alignLeft),
+        run: toggleMark(schema.marks.alignLeft),
+      },
+      center: {
+        title: "Center align text",
+        content: icons.align_center,
+        active: markActive(schema.marks.alignCenter),
+        run: toggleMark(schema.marks.alignCenter),
+      },
+      justify: {
+        title: "Justify align text",
+        content: icons.align_justify,
+        active: markActive(schema.marks.alignJustify),
+        run: toggleMark(schema.marks.alignJustify),
+      },
+      right: {
+        title: "Right align text",
+        content: icons.align_right,
+        active: markActive(schema.marks.alignRight),
+        run: toggleMark(schema.marks.alignRight),
+      },
     },
-    right: {
-      title: "Float right",
-      content: icons.float_right,
-      active: markActive(schema.marks.floatRight),
-      run: toggleMark(schema.marks.floatRight)
-    }
-  },
-  history: {
-    undo: {
-      title: "Undo last change",
-      content: icons.undo,
-      enable: undo,
-      run: undo
+
+    headings_dropdown: {
+      title: "Change Heading",
+      content: "Heading",
+      // classname: "dropdown-menu-list",
+      children: ["1", "2", "3", "4", "5", "6"].reduce((acc, level) => {
+        acc[level] = {
+          title: `Heading ${level}`,
+          content: `Level ${level}`,
+          active: blockActive(schema.nodes.heading, { level: level }),
+          enable: setBlockType(schema.nodes.heading, { level: level }),
+          run: setBlockType(schema.nodes.heading, { level: level }),
+        };
+
+        return acc;
+      }, {}),
     },
-    redo: {
-      title: "Redo last undone change",
-      content: icons.redo,
-      enable: redo,
-      run: redo
-    }
-  }
-};
+
+    embed_dropdown: {
+      title: "Embed Content",
+      content: "Embed",
+      classname: "dropdown-menu-list",
+      children: ["Instagram", "YouTube", "Twitframe"].reduce((acc, service) => {
+        acc[service] = {
+          title: `${service}`,
+          content: `${service}`,
+          enable: canInsert(schema.nodes.iframe),
+          run: (state, dispatch, view) => {
+            zesty.trigger("PROSEMIRROR_DIALOG_OPEN", "showEmbedModal", {
+              service,
+              view,
+            });
+          },
+        };
+
+        return acc;
+      }, {}),
+    },
+
+    blocks: {
+      plain: {
+        title: "Change to paragraph",
+        content: icons.paragraph,
+        active: blockActive(schema.nodes.paragraph),
+        enable: setBlockType(schema.nodes.paragraph),
+        run: setBlockType(schema.nodes.paragraph),
+      },
+      code_block: {
+        title: "Change to code block",
+        content: icons.code_block,
+        active: blockActive(schema.nodes.code_block),
+        enable: setBlockType(schema.nodes.code_block),
+        run: setBlockType(schema.nodes.code_block),
+      },
+      blockquote: {
+        title: "Change to block quote",
+        content: icons.blockquote,
+        active: blockActive(schema.nodes.blockquote),
+        enable: setBlockType(schema.nodes.blockquote),
+        run: setBlockType(schema.nodes.blockquote),
+      },
+      bullet_list: {
+        title: "Wrap in bullet list",
+        content: icons.bullet_list,
+        active: blockActive(schema.nodes.bullet_list),
+        enable: wrapInList(schema.nodes.bullet_list),
+        run: wrapInList(schema.nodes.bullet_list),
+      },
+      ordered_list: {
+        title: "Wrap in ordered list",
+        content: icons.ordered_list,
+        active: blockActive(schema.nodes.ordered_list),
+        enable: wrapInList(schema.nodes.ordered_list),
+        run: wrapInList(schema.nodes.ordered_list),
+      },
+      indent: {
+        title: "Indent",
+        content: icons.indent,
+        active: markActive(schema.marks.indent),
+        run: toggleMark(schema.marks.indent),
+      },
+      // outdent: {
+      //   title: "Dedent",
+      //   content: icons.outdent,
+      //   active: markActive(schema.marks.dedent),
+      //   run: toggleMark(schema.marks.dedent)
+      // }
+    },
+
+    insert: {
+      // footnote: {
+      //   title: "Insert footnote",
+      //   content: icons.footnote,
+      //   enable: canInsert(schema.nodes.footnote),
+      //   run: (state, dispatch) => {
+      //     const footnote = schema.nodes.footnote.create();
+      //     dispatch(state.tr.replaceSelectionWith(footnote));
+      //   }
+      // },
+      hr: {
+        title: "Insert horizontal rule",
+        content: "HR",
+        enable: canInsert(schema.nodes.hr),
+        run: (state, dispatch) => {
+          const hr = schema.nodes.hr.create();
+          dispatch(state.tr.replaceSelectionWith(hr));
+        },
+      },
+      table: {
+        title: "Insert table",
+        content: icons.table,
+        enable: canInsert(schema.nodes.table),
+        run: (state, dispatch) => {
+          // const { from } = state.selection
+          let rowCount = window && window.prompt("How many rows?", 2);
+          let colCount = window && window.prompt("How many columns?", 2);
+
+          const cells = [];
+          while (colCount--) {
+            cells.push(schema.nodes.table_cell.createAndFill());
+          }
+
+          const rows = [];
+          while (rowCount--) {
+            rows.push(schema.nodes.table_row.createAndFill(null, cells));
+          }
+
+          const body = schema.nodes.table_body.createAndFill(null, rows);
+          const table = schema.nodes.table.createAndFill(null, body);
+
+          dispatch(state.tr.replaceSelectionWith(table));
+
+          // const tr = state.tr.replaceSelectionWith(table)
+          // tr.setSelection(Selection.near(tr.doc.resolve(from)))
+          // dispatch(tr.scrollIntoView())
+          // view.focus()
+        },
+      },
+      // table: {
+      // addColumnBefore: {
+      //   title: 'Insert column before',
+      //   content: icons.after,
+      //   active: addColumnBefore, // TOOD: active -> select
+      //   run: addColumnBefore
+      // },
+      // addColumnAfter: {
+      //   title: 'Insert column before',
+      //   content: icons.before,
+      //   active: addColumnAfter, // TOOD: active -> select
+      //   run: addColumnAfter
+      // }
+      // }
+    },
+    special_character_dropdown: {
+      title: "Insert special character",
+      content: "Special Character",
+      classname: "dropdown-menu-row",
+      children: characters.reduce((acc, char) => {
+        acc[char] = {
+          title: `Insert Character: ${char}`,
+          content: char,
+          enable: canInsert(schema.nodes.text),
+          run: (state, dispatch) => {
+            dispatch(state.tr.replaceSelectionWith(schema.text(char)));
+          },
+        };
+
+        return acc;
+      }, {}),
+    },
+    media: {
+      image: {
+        title: "Insert image from media library",
+        content: icons.image,
+        enable: canInsert(schema.nodes.image),
+        run: (state, dispatch) => {
+          options.mediaBrowser({
+            limit: 10,
+            callback: (images) => {
+              const imageNodes = images.map((image) =>
+                schema.nodes.image.createAndFill({
+                  src: image.url,
+                  title: image.title,
+                  "data-zuid": image.id,
+                })
+              );
+
+              dispatch(
+                state.tr.replaceSelection(
+                  new Slice(Fragment.from(imageNodes), 0, 0)
+                )
+              );
+            },
+          });
+        },
+      },
+      left: {
+        title: "Float left",
+        content: icons.float_left,
+        active: markActive(schema.marks.floatLeft),
+        run: toggleMark(schema.marks.floatLeft),
+      },
+      right: {
+        title: "Float right",
+        content: icons.float_right,
+        active: markActive(schema.marks.floatRight),
+        run: toggleMark(schema.marks.floatRight),
+      },
+    },
+    history: {
+      undo: {
+        title: "Undo last change",
+        content: icons.undo,
+        enable: undo,
+        run: undo,
+      },
+      redo: {
+        title: "Redo last undone change",
+        content: icons.redo,
+        enable: redo,
+        run: redo,
+      },
+    },
+  };
+}

--- a/core/src/FieldTypeEditor/FieldTypeEditor.js
+++ b/core/src/FieldTypeEditor/FieldTypeEditor.js
@@ -82,11 +82,23 @@ export const FieldTypeEditor = React.memo(function FieldTypeEditor(props) {
     switch (editorType) {
       case "wysiwyg_basic":
       case "wysiwyg_advanced":
-        return <BasicEditor value={content} onChange={onChange} />;
+        return (
+          <BasicEditor
+            value={content}
+            onChange={onChange}
+            mediaBrowser={props.mediaBrowser}
+          />
+        );
       case "markdown":
         return <MarkdownEditor value={content} onChange={onChange} />;
       case "article_writer":
-        return <InlineEditor value={content} onChange={onChange} />;
+        return (
+          <InlineEditor
+            value={content}
+            onChange={onChange}
+            mediaBrowser={props.mediaBrowser}
+          />
+        );
       case "html":
         return <HtmlEditor value={content} onChange={onChange} />;
       default:


### PR DESCRIPTION
allow consumer to pass mediaBrowser prop to FieldTypeEditor to wire up media manager modal
best viewed with whitespace changes ignored