### PR TITLE
bump peer dependencies for react 17, remove broken prosemirror footnotes

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -22,8 +22,9 @@
     "tinymce": "^5.3.2"
   },
   "peerDependencies": {
-    "@aeaton/react-prosemirror": "^0.21.1",
-    "@aeaton/react-prosemirror-config-default": "^0.11.0",
+    "@aeaton/prosemirror-footnotes": "^2.0.2",
+    "@aeaton/react-prosemirror": "^2.0.3",
+    "@aeaton/react-prosemirror-config-default": "^2.0.3",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.14",
@@ -31,9 +32,9 @@
     "classnames": "^2.2.6",
     "flatpickr": "^4.5.2",
     "lodash.debounce": "^4.0.8",
-    "react": "^16.10.2",
+    "react": "^17.0.2",
     "react-codemirror2": "^7.0.0",
-    "react-dom": "^16.10.2",
+    "react-dom": "^17.0.2",
     "react-flatpickr": "3.10.6",
     "react-router-dom": "^5.1.2",
     "showdown": "^1.9.0",

--- a/core/src/FieldTypeEditor/Editors/react-prosemirror-plugins/index.js
+++ b/core/src/FieldTypeEditor/Editors/react-prosemirror-plugins/index.js
@@ -1,1 +1,1 @@
-export { default as plugins } from "./plugins";
+export { plugins } from "./plugins";

--- a/core/src/FieldTypeEditor/Editors/react-prosemirror-plugins/plugins.js
+++ b/core/src/FieldTypeEditor/Editors/react-prosemirror-plugins/plugins.js
@@ -3,24 +3,24 @@ import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";
 // import { columnResizing, tableEditing } from "prosemirror-tables";
 import { placeholder } from "@aeaton/prosemirror-placeholder";
-import { footnotes } from "@aeaton/prosemirror-footnotes";
+// import { footnotes } from "@aeaton/prosemirror-footnotes";
 
 import "prosemirror-tables/style/tables.css";
 import "prosemirror-gapcursor/style/gapcursor.css";
-import "@aeaton/prosemirror-footnotes/style/footnotes.css";
+// import "@aeaton/prosemirror-footnotes/style/footnotes.css";
 import "@aeaton/prosemirror-placeholder/style/placeholder.css";
 
 import keys from "./keys";
 import rules from "./rules";
 
-export default [
+export const plugins = [
   rules,
   keys,
   placeholder(),
-  footnotes(),
+  // footnotes(),
   dropCursor(),
   gapCursor(),
-  history()
+  history(),
   // columnResizing(),
   // tableEditing()
 ];


### PR DESCRIPTION
bumping these dependencies caused missing footnotes import.
"@aeaton/react-prosemirror": "^2.0.3"
"@aeaton/react-prosemirror-config-default": "^2.0.3"

Even if I include "@aeaton/prosemirror-footnotes": "^2.0.2"
the `import { footnotes }` line still returns `undefined`

Current proposed solution is to disable footnotes support in Prosemirror