### PR TITLE
removing width 16px on icon, remove disabled border

### DIFF
--- a/core/src/Button/Button.less
+++ b/core/src/Button/Button.less
@@ -42,7 +42,6 @@ SIZE: compact, small
   .icon {
     margin-right: 8px;
     font-size: 13px;
-    width: 16px;
   }
 
   &:hover,

--- a/core/src/colors.less
+++ b/core/src/colors.less
@@ -43,7 +43,6 @@
 .disabled {
   background-color: @btnDisabled;
   color: @zesty-light-grey;
-  border: 1px @btnDisabled solid;
 }
 
 // Backgrounds Colors


### PR DESCRIPTION
Before 
<img width="218" alt="Screen Shot 2021-09-08 at 4 06 16 PM" src="https://user-images.githubusercontent.com/22800749/132597355-070935c4-080b-494d-accb-6aaaa73a9d6f.png">

After 
<img width="205" alt="Screen Shot 2021-09-08 at 4 10 22 PM" src="https://user-images.githubusercontent.com/22800749/132597373-f2ed7251-4620-4f4b-bab4-2c92f644c5be.png">




fixes https://github.com/zesty-io/manager-ui/issues/893


After
<img width="214" alt="Screen Shot 2021-09-08 at 4 10 53 PM" src="https://user-images.githubusercontent.com/22800749/132597410-e15a6c95-5f7c-4e22-81a6-3f0536f00044.png">
