### PR TITLE
fixing cancel button color

### DIFF
--- a/core/src/Button/Button.less
+++ b/core/src/Button/Button.less
@@ -61,7 +61,7 @@ SIZE: compact, small
 
   &.cancel {
     background-color: @c-cancel;
-    color: @zesty-light-grey
+    color: @white
   }
   &.warn {
     .bgd-warn();

--- a/core/src/colors.less
+++ b/core/src/colors.less
@@ -38,7 +38,7 @@
 @c-secondary: @zesty-blue;
 @c-warn: @zesty-red;
 @c-disabled: #1a202c;
-@c-cancel: #2A2E3D;
+@c-cancel: #6E7480;
 
 .disabled {
   background-color: @btnDisabled;


### PR DESCRIPTION
updated cancel button color used color picker extension on legacy. This method was used to not use opacity 0.6  