### PR TITLE
Change extended toolbar mode to be sliding

### DIFF
--- a/core/src/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/core/src/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -80,6 +80,7 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
              table zestyMediaApp media embed charmap insertdatetime | \
              pastetext removeformat | fullscreen code help | undo redo",
             contextmenu: "bold italic link | copy paste",
+            toolbar_mode: 'sliding',
 
             relative_urls: false,
             // plugin settings


### PR DESCRIPTION
tinyMCE toolbar is already sticky. 

This PR updates the extended toolbar to not be a popover but to slide in right below the already sticky toolbar to avoid user confusion

https://www.loom.com/share/2f6247c955ed4cee90c8b4886f11ac1c